### PR TITLE
Update version numbers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ SHELL=/bin/sh
 OS=$(shell uname || uname -s)
 ARCH=$(shell arch || uname -m)
 
-GIR_TO_D_VERSION=v0.13.0
+GIR_TO_D_VERSION=v0.15.0
 
 ifndef DC
     ifneq ($(strip $(shell which dmd 2>/dev/null)),)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('GIR-to-D', 'd', version: '0.13.0')
+project('GIR-to-D', 'd', version: '0.15.0')
 
 source = [
 	'source/girtod.d',


### PR DESCRIPTION
This updates the version numbers in Meson/Makefile to match reality.

It would be awesome to get a new gir-to-d release as soon as possible, because Git master contains quite a lot of bugfixes that would be great to have!