### PR TITLE
Build glibd library from autogenerated bindings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,36 +1,85 @@
-project('GIR-to-D', 'd', version: '0.15.0')
+project('GIR-to-D', 'd',
+    meson_version: '>=0.46',
+    license: 'LGPL-3.0',
+    version: '0.15.0'
+)
+
+glibd_soversion = '0'
+glibd_version = '2.56'
 
 source = [
-	'source/girtod.d',
-	'source/gtd/DefReader.d',
-	'source/gtd/GlibTypes.d',
-	'source/gtd/GirAlias.d',
-	'source/gtd/GirConstant.d',
-	'source/gtd/GirEnum.d',
-	'source/gtd/GirField.d',
-	'source/gtd/GirFunction.d',
-	'source/gtd/GirPackage.d',
-	'source/gtd/GirStruct.d',
-	'source/gtd/GirType.d',
-	'source/gtd/GirVersion.d',
-	'source/gtd/GirWrapper.d',
-	'source/gtd/IndentedStringBuilder.d',
-	'source/gtd/Log.d',
-	'source/gtd/LinkedHasMap.d',
-	'source/gtd/WrapException.d',
-	'source/gtd/XMLReader.d'
+    'source/girtod.d',
+    'source/gtd/DefReader.d',
+    'source/gtd/GlibTypes.d',
+    'source/gtd/GirAlias.d',
+    'source/gtd/GirConstant.d',
+    'source/gtd/GirEnum.d',
+    'source/gtd/GirField.d',
+    'source/gtd/GirFunction.d',
+    'source/gtd/GirPackage.d',
+    'source/gtd/GirStruct.d',
+    'source/gtd/GirType.d',
+    'source/gtd/GirVersion.d',
+    'source/gtd/GirWrapper.d',
+    'source/gtd/IndentedStringBuilder.d',
+    'source/gtd/Log.d',
+    'source/gtd/LinkedHasMap.d',
+    'source/gtd/WrapException.d',
+    'source/gtd/XMLReader.d'
 ]
 
 sources_dir = include_directories('source/')
 
 version = vcs_tag(command: ['git', 'describe', '--dirty=+', '--tags'], input: 'VERSION.in', output: 'VERSION')
-# d_import_dirs was added in meson 0.43 for now add -J manually.
-add_project_arguments('-J'+meson.current_build_dir(), language: 'd')
+
+
+if get_option('build-glibd')
+    python = find_program('python3')
+    glib_dep = dependency('glib-2.0')
+    pkgc = import('pkgconfig')
+
+    message('Building temporary girtod binary...')
+    girtod_temp_create = run_command(python.path(), 'wrap/meson/create-temp-girtod.py')
+    if girtod_temp_create.returncode() != 0
+        error('Unable to build temporary GirToD binary:\n' + girtod_gen.stderr() + girtod_gen.stdout())
+    endif
+
+    message('Generating D interfaces from GIR...')
+    girtod_gen = run_command(python.path(),
+                             'wrap/meson/generate-bindings.py',
+                             'wrap/')
+    if girtod_gen.returncode() != 0
+        error('Unable to build D intefaces from GIR:\n' + girtod_gen.stderr() + girtod_gen.stdout())
+    endif
+
+    gir_bind_dir = include_directories(join_paths('wrap.gen', 'glibd'))
+    gir_binding_sources = girtod_gen.stdout().strip().split('\n')
+
+    glibd_lib = library('glibd-2.0',
+        [gir_binding_sources],
+        include_directories: [gir_bind_dir],
+        dependencies: [glib_dep],
+        install: true,
+        version: glibd_version,
+        soversion: glibd_soversion
+    )
+
+    pkgc.generate(name: 'glibd-2.0',
+        libraries: glibd_lib,
+        subdirs: 'd/glibd',
+        version: glibd_version,
+        requires: ['glib-2.0'],
+        description: 'D bindings for the GLib C Utility Library.'
+    )
+
+    install_subdir(join_paths(meson.build_root(), 'wrap.gen', 'glibd'), install_dir: 'include/d/glibd/')
+
+endif
 
 executable(
-	'girtod',
-	[source, version],
-	include_directories : [sources_dir],
-#	d_import_dirs : meson.build_root(),
-	install : true
+    'girtod',
+    [source, version],
+    include_directories : [sources_dir],
+    d_import_dirs : meson.build_root(),
+    install: true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('build-glibd',
+       type: 'boolean',
+       value: true,
+       description: 'Whether we should build the glibd library.'
+)

--- a/wrap/APILookup.txt
+++ b/wrap/APILookup.txt
@@ -1,0 +1,57 @@
+#
+# This file is part of GirToD.
+#
+# GirToD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version, with
+# some exceptions, please read the COPYING file.
+#
+# GirToD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with GirToD.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# define the license to use
+license: start
+/*
+ * Licensed under the GNU Lesser General Public License Version 3
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the license, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// generated automatically - do not change
+// find conversion definition on APILookup.txt
+// implement new conversion functionalities on the wrap.utils pakage
+
+
+license: end
+
+includeComments: y
+outputRoot: generated
+
+###########################################################
+### predifined: lib
+###########################################################
+
+srcDir: .
+lookup: APILookupGLib.txt
+lookup: APILookupGThread.txt
+lookup: APILookupGObject.txt
+lookup: APILookupGio.txt

--- a/wrap/APILookupGLib.txt
+++ b/wrap/APILookupGLib.txt
@@ -1,0 +1,2098 @@
+﻿# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: glib
+file: GLib-2.0.gir
+file: GModule-2.0.gir
+
+addAliases: start
+	public alias uint uid_t;
+	public alias int pid_t;
+
+	version( Windows )
+	{
+		alias int glong;
+		alias uint gulong;
+	}
+	else version( X86_64 )
+	{
+		alias long glong;
+		alias ulong gulong;
+	}
+	else
+	{
+		alias int glong;
+		alias uint gulong;
+	}
+
+	version (Windows)
+	{
+		private import core.stdc.stdio;
+
+		static if( !is(typeof(fdopen(0, null))) )
+		{
+			extern (C) FILE*  fdopen(int, char*);
+		}
+	}
+
+	struct Scoped(T)
+	{
+		T payload;
+
+		alias payload this;
+
+		@disable this();
+		@disable this(this);
+
+		~this()
+		{
+			.destroy(payload);
+		}
+	}
+
+	auto getScopedGobject(T, Args...)(auto ref Args args) if (is(T == class))
+	{
+		Scoped!(T) result = void;
+		result.payload = new T(args);
+
+		return result;
+	}
+
+	/**
+	 * Get the length of a zero terminated array.
+	 */
+	size_t getArrayLength(T)(T* arr)
+	{
+		size_t len;
+
+		for ( ; arr[len]; len++ ){}
+
+		return len;
+	}
+
+	unittest
+	{
+		assert(getArrayLength("aaaaaaaaa\0".ptr) == 9);
+	}
+
+	Type* gMalloc(Type)()
+	{
+		import glib.c.functions;
+		return cast(Type*)g_malloc0(Type.sizeof);
+	}
+
+	alias void* GIConv;
+addAliases: end
+
+addEnums: start
+
+	enum GPriority
+	{
+		HIGH = -100,
+		DEFAULT = 0,
+		HIGH_IDLE = 100,
+		DEFAULT_IDLE = 200,
+		LOW = 300
+	}
+
+addEnums: end
+
+noConstant: DIR_SEPARATOR
+noConstant: DIR_SEPARATOR_S
+noConstant: E
+noConstant: LN10
+noConstant: LN2
+noConstant: LOG_2_BASE_10
+noConstant: PI
+noConstant: PI_2
+noConstant: PI_4
+noConstant: SEARCHPATH_SEPARATOR
+noConstant: SEARCHPATH_SEPARATOR_S
+noConstant: SQRT2
+noConstant: VERSION_MIN_REQUIRED 
+
+struct: Array
+class: ArrayG
+
+struct: Base64
+move: base64_decode_step Base64 decode_step
+move: base64_decode_inplace Base64 decode_inplace
+noCode: decode_step
+array: decode_inplace Return out_len
+code: start
+	/**
+	 * Incrementally decode a sequence of binary data from its Base-64 stringified
+	 * representation. By calling this function multiple times you can convert
+	 * data in chunks to avoid having to have the full encoded data in memory.
+	 *
+	 * The output buffer must be large enough to fit all the data that will
+	 * be written to it. Since base64 encodes 3 bytes in 4 chars you need
+	 * at least: (@len / 4) * 3 + 3 bytes (+ 3 may be needed in case of non-zero
+	 * state).
+	 *
+	 * Params:
+	 *     inn = binary input data
+	 *     len = max length of @in data to decode
+	 *     output = output buffer
+	 *     state = Saved state between steps, initialize to 0
+	 *     save = Saved state between steps, initialize to 0
+	 *
+	 * Return: The number of bytes of output that was written
+	 *
+	 * Since: 2.12
+	 */
+	public static size_t decodeStep(string inn, ref ubyte[] output, ref int state, ref uint save)
+	{
+		auto p = g_base64_decode_step(Str.toStringz(inn), cast(int)inn.length, cast(char*)output.ptr, &state, &save);
+
+		return p;
+	}
+code: end
+
+struct: BookmarkFile
+out: load_from_data_dirs full_path
+array: set_groups groups length
+
+struct: ByteArray
+class: ByteArray
+
+struct: Bytes
+noCode: new_take
+noCode: new_static
+
+struct: Checksum
+noCode: get_digest
+code: start
+	/**
+	 * Gets the digest from checksum as a raw binary vector and places it
+	 * into buffer. The size of the digest depends on the type of checksum.
+	 *
+	 * Once this function has been called, the Checksum is closed and can
+	 * no longer be updated with update().
+	 *
+	 * Params:
+	 *     buffer = output buffer
+	 *     digestLen = an inout parameter. The caller initializes it to the size of buffer.
+	 *         After the call it contains the length of the digest.
+	 *
+	 * Since: 2.16
+	 */
+	public void getDigest(ref ubyte[] buffer)
+	{
+		size_t digestLen = buffer.length;
+
+		g_checksum_get_digest(gChecksum, buffer.ptr, &digestLen);
+
+		buffer = buffer[0 .. digestLen];
+	}
+code: end
+
+struct: ConstructionException
+namespace:
+code: start
+	class ConstructionException : Exception
+	{
+		this(string message)
+		{
+			super(message);
+		}
+
+		override string toString()
+		{
+			return "Construction failure, " ~ msg;
+		}
+	}
+code: end
+
+struct: DateTime
+structWrap: gpointer DateTime
+noCode: new_now_utc
+noCode: new_now_local
+noCode: new_from_unix_local
+noCode: new_from_unix_utc
+noCode: new_from_timeval_local
+noCode: new_from_timeval_utc
+noCode: new_local
+noCode: new_utc
+noCode: hash
+code: start
+	/**
+	 * Creates a DateTime corresponding to the given Unix time t
+	 * Unix time is the number of seconds that have elapsed since 1970-01-01
+	 * 00:00:00 UTC, regardless of the local time offset.
+	 *
+	 * This call can fail (ConstructionException) if t represents a time outside
+	 * of the supported range of GDateTime.
+	 * You should release the return value by calling unref()
+	 * when you are done with it
+	 *
+	 * Params:
+	 *     t   = the Unix time
+	 *     utc = If true use utc else use the local timezone.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.26
+	 */
+	public this (long t, bool utc = true)
+	{
+		GDateTime* p;
+
+		if ( utc )
+		{
+			p = g_date_time_new_from_unix_utc(t);
+		}
+		else
+		{
+			p = g_date_time_new_from_unix_local(t);
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_date_time_new_from_unix_local(t)");
+		}
+		this(cast(GDateTime*) p);
+	}
+
+	/**
+	 * Creates a DateTime corresponding to the given TimeVal tv.
+	 * The time contained in a TimeVal is always stored in the form of
+	 * seconds elapsed since 1970-01-01 00:00:00 UTC, regardless of the
+	 * local time offset.
+	 *
+	 * This call can fail (ConstructionException) if tv represents a time outside
+	 * of the supported range of DateTime.
+	 * You should release the return value by calling unref()
+	 * when you are done with it.
+	 *
+	 * Params:
+	 *     tv  = a GTimeVal
+	 *     utc = If true use utc else use the local timezone.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.26
+	 */
+	public this (ref GTimeVal tv, bool utc = true)
+	{
+		GDateTime* p;
+
+		if ( utc )
+		{
+			p = g_date_time_new_from_timeval_utc(&tv);
+		}
+		else
+		{
+			p = g_date_time_new_from_timeval_local(&tv);
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_date_time_new_from_timeval_local((tv is null) ? null : tv.getTimeValStruct())");
+		}
+		this(cast(GDateTime*) p);
+	}
+
+	/** */
+	override bool opEquals(Object rhs)
+	{
+		DateTime date = cast(DateTime)rhs;
+
+		if ( date is null )
+			return false;
+
+		return equal(this, date) != 0;
+	}
+
+	/** */
+	override int opCmp(Object rhs)
+	{
+		DateTime date = cast(DateTime)rhs;
+
+		if ( date is null )
+			return int.min;
+
+		return compare(this, date);
+	}
+
+	/** */
+	override nothrow @trusted hash_t toHash()
+	{
+		return hash();
+	}
+
+	/**
+	 * Hashes datetime into a guint, suitable for use within GHashTable.
+	 * Since 2.26
+	 * Params:
+	 * datetime = a GDateTime
+	 * Returns: a guint containing the hash
+	 */
+	public nothrow @trusted uint hash()
+	{
+		try
+		{
+			return g_date_time_hash(gDateTime);
+		}
+		catch(Exception e)
+		{
+			return 0;
+		}
+	}
+code: end
+
+struct: Dir
+class: Directory
+
+struct: Error
+class: ErrorG
+move: propagate_error Error
+move: set_error_literal Error
+out: set_error_literal err
+out: propagate_error dest
+
+struct: GException
+namespace:
+import: glib.ErrorG
+import: glib.Str
+code: start
+	class GException : Exception
+	{
+		ErrorG error;
+
+		this(ErrorG error)
+		{
+			super( Str.toString(error.getErrorGStruct().message) );
+			this.error = error;
+		}
+	}
+code: end
+
+struct: GLib
+namespace:
+code: start
+	static import glib.Version;
+	deprecated("moves to the glib.Version module")
+	alias glib.Version.Version Version;
+code: end
+
+struct: HashTable
+class: HashTable
+
+struct: Hmac
+noCode: get_digest
+move: compute_hmac_for_data Hmac
+move: compute_hmac_for_string Hmac
+move: compute_hmac_for_bytes Hmac
+array: compute_hmac_for_data data length
+array: compute_hmac_for_string str length
+code: start
+	/**
+	 * Gets the digest from checksum as a raw binary array and places it
+	 * into buffer. The size of the digest depends on the type of checksum.
+	 *
+	 * Once this function has been called, the Hmac is closed and can
+	 * no longer be updated with update().
+	 *
+	 * Params:
+	 *     buffer = output buffer
+	 *
+	 * Since: 2.30
+	 */
+	public void getDigest(ref ubyte[] buffer)
+	{
+		size_t digestLen = buffer.length;
+
+		g_hmac_get_digest(gHmac, buffer.ptr, &digestLen);
+
+		buffer = buffer[0 .. digestLen];
+	}
+code: end
+
+struct: IConv
+namespace:
+noStruct: true
+ref: iconv inbuf
+out: iconv inbytes_left
+array: iconv inbuf inbytes_left
+ref: iconv outbuf
+out: iconv outbytes_left
+array: iconv outbuf outbytes_left
+
+struct: Idle
+class: Idle
+cType:
+code: start
+	/** Holds all idle delegates */
+	private bool delegate()[] idleListeners;
+	/** Our idle ID */
+	private uint idleID;
+	/** The priority this class was instantiated with */
+	private GPriority priority = GPriority.DEFAULT_IDLE;
+
+	/**
+	 * Creates a new idle cycle.
+	 * Params:
+	 *    	dlg = the delegate to be executed
+	 *    	fireNow = When true the delegate will be executed emmidiatly
+	 */
+	this(bool delegate() dlg, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		idleListeners ~= dlg;
+		idleID = g_idle_add_full(priority, cast(GSourceFunc)&idleCallback, cast(void*)this, cast(GDestroyNotify)&destroyIdleNotify);
+	}
+
+	/**
+	 * Creates a new idle cycle.
+	 * Params:
+	 *    	dlg = the delegate to be executed
+	 *      priority = Priority for the idle function
+	 *    	fireNow = When true the delegate will be executed emmidiatly
+	 */
+	this(bool delegate() dlg, GPriority priority, bool fireNow=false)
+	{
+		this.priority = priority;
+
+		if ( fireNow && !dlg() )
+			return;
+
+		idleListeners ~= dlg;
+		idleID = g_idle_add_full(priority, cast(GSourceFunc)&idleCallback, cast(void*)this, cast(GDestroyNotify)&destroyIdleNotify);
+	}
+
+	/** */
+	public void stop()
+	{
+		if ( idleID > 0 )
+			g_source_remove(idleID);
+	}
+
+	/**
+	 * Removes the idle from gtk
+	 */
+	~this()
+	{
+		stop();
+	}
+
+	/**
+	 * Adds a new delegate to this idle cycle
+	 * Params:
+	 *    	dlg =
+	 *    	fireNow =
+	 */
+	public void addListener(bool delegate() dlg, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		idleListeners ~= dlg;
+
+		if ( idleID == 0 )
+			idleID = g_idle_add_full(priority, cast(GSourceFunc)&idleCallback, cast(void*)this, cast(GDestroyNotify)&destroyIdleNotify);
+	}
+
+	/*
+	 * Executes all delegates on the execution list
+	 * Returns: false if the callback should be removed.
+	 */
+	extern(C) static bool idleCallback(Idle idle)
+	{
+		bool runAgain = false;
+		int i = 0;
+
+		while ( i<idle.idleListeners.length )
+		{
+			if ( !idle.idleListeners[i]() )
+			{
+				idle.idleListeners = idle.idleListeners[0..i] ~ idle.idleListeners[i+1..$];
+			}
+			else
+			{
+				runAgain = true;
+				++i;
+			}
+		}
+
+		return runAgain;
+	}
+
+	/*
+	 * Reset the idle object when it's destroyed on the GTK side.
+	 */
+	extern(C) static void destroyIdleNotify(Idle idle)
+	{
+		idle.idleListeners.length = 0;
+		idle.idleID = 0;
+	}
+code: end
+
+struct: IOChannel
+array: read_line str_return length
+out: read_line_string terminator_pos
+array: write_chars buf count
+
+struct: List
+class: ListG
+import: gobject.ObjectG
+import: glib.Str
+code: start
+  	/** */
+	@property void* data()
+	{
+		return gList.data;
+	}
+
+  	/**
+	 * get the next element
+	 * Returns: the next element, or NULL if there are no more elements.
+	 */
+	@property ListG next()
+	{
+		if ( gList.next is null )
+		{
+			return null;
+		}
+
+		return new ListG(gList.next);
+	}
+
+	/**
+	 * get the previous element
+	 * Returns: the previous element, or NULL if there are no more elements.
+	 */
+	@property ListG previous()
+	{
+		if ( gList.prev is null )
+		{
+			return null;
+		}
+
+		return new ListG(gList.prev);
+	}
+
+	/**
+	 * Turn the list into a D array of the desiered type.
+	 * Type T wraps should match the type of the data.
+	 */
+	public T[] toArray(T, TC = getCType!T)()
+		if ( is(T == class) )
+	{
+		T[] arr = new T[length()];
+		ListG list = this;
+		size_t count;
+
+		while(list !is null && count < arr.length)
+		{
+			arr[count] = ObjectG.getDObject!(T)(cast(TC)list.data);
+			list = list.next();
+			count++;
+		}
+
+		return arr;
+	}
+
+	/** Ditto */
+	public T[] toArray(T)()
+		if ( is ( T == string ) )
+	{
+		T[] arr = new T[length()];
+		ListG list = this;
+		size_t count;
+
+		while(list !is null && count < arr.length)
+		{
+			arr[count] = Str.toString(cast(char*)list.data);
+			list = list.next();
+			count++;
+		}
+
+		return arr;
+	}
+
+	private template getCType(T)
+	{
+		static if ( is(T == class) )
+			alias getCType = typeof(T.tupleof[0]);
+		else
+			alias getCType = void*;
+	}
+
+	unittest
+	{
+		import gobject.Value;
+
+		auto list = new ListG(null);
+		list = list.append(new Value(0).getValueStruct());
+		list = list.append(new Value(1).getValueStruct());
+		auto arr = list.toArray!Value();
+
+		assert(arr[0].getInt() == 0);
+		assert(arr[1].getInt() == 1);
+
+		list = new ListG(null);
+		list = list.append(cast(void*)"test\0".ptr);
+		list = list.append(cast(void*)"test2\0".ptr);
+
+		assert(["test", "test2"] == list.toArray!string());
+	}
+code: end
+
+struct: MainContext
+in: query fds
+in: query n_fds
+
+struct: MarkupParseContext
+class: SimpleXML
+
+struct: MemorySlice
+namespace:
+code: start
+	public T* sliceNew(T)()
+	{
+		// We cant use sliceAlloc for the GLib array types.
+		// the actual array structs are larger than the ones used in the API.
+		static if ( is( T == GArray ) )
+			return g_array_new(false, false, 1);
+		else static if ( is( T == GByteArray ) )
+			return g_byte_array_new();
+		else static if ( is( T == GPtrArray ) )
+			return g_ptr_array_new();
+		else
+			return cast(T*)g_slice_alloc0(T.sizeof);
+	}
+	
+	public T* sliceAlloc(T)()
+	{
+		return cast(T*)g_slice_alloc0(T.sizeof);
+	}
+
+	public T* sliceDup(T)(T* memBlock)
+	{
+		return cast(T*)g_slice_copy(T.sizeof, memBlock);
+	}
+ 
+	public void sliceFree(T)(T* memBlock)
+ 	{
+ 		 g_slice_free1(T.sizeof, memBlock);
+ 	}
+code: end
+
+struct: Module
+in: symbol symbol
+
+struct: PatternSpec
+class: Pattern
+
+struct: PtrArray
+class: PtrArray
+code: start
+	/**
+	 * Number of pointers in the array
+	 */
+	public uint len() pure
+	{
+		return gPtrArray.len;
+	}
+
+	/**
+	 * Returns the pointer at the given index of the pointer array.
+	 *
+	 * This does not perform bounds checking on the given index, so
+	 * you are responsible for checking it against the array length.
+	 */
+	public void* index(uint idx)
+	{
+		return (gPtrArray.pdata)[idx];
+	}
+code: end
+
+struct: Queue
+class: QueueG
+
+struct: Rand
+class: RandG
+alias: double randDouble
+alias: int randInt
+array: new_with_seed_array seed seed_length
+
+struct: Scanner
+class: ScannerG
+
+struct: SList
+class: ListSG
+import: gobject.ObjectG
+import: glib.Str
+code: start
+  	/** */
+	@property void* data()
+	{
+		return gSList.data;
+	}
+
+  	/**
+	 * get the next element
+	 * Returns: the next element, or NULL if there are no more elements.
+	 */
+	@property ListSG next()
+	{
+		if ( gSList.next is null )
+		{
+			return null;
+		}
+
+		return new ListSG(gSList.next);
+	}
+
+	/**
+	 * Turn the list into a D array of the desiered type.
+	 * Type T wraps should match the type of the data.
+	 */
+	public T[] toArray(T, TC = getCType!T)()
+		if ( is(T == class) )
+	{
+		T[] arr = new T[length()];
+		ListSG list = this;
+		size_t count;
+
+		while(list !is null && count < arr.length)
+		{
+			arr[count] = ObjectG.getDObject!(T)(cast(TC)list.data);
+			list = list.next();
+			count++;
+		}
+
+		return arr;
+	}
+
+	/** Ditto */
+	public T[] toArray(T)()
+		if ( is ( T == string ) )
+	{
+		T[] arr = new T[length()];
+		ListSG list = this;
+		size_t count;
+
+		while(list !is null && count < arr.length)
+		{
+			arr[count] = Str.toString(cast(char*)list.data);
+			list = list.next();
+			count++;
+		}
+
+		return arr;
+	}
+
+	private template getCType(T)
+	{
+		static if ( is(T == class) )
+			alias getCType = typeof(T.tupleof[0]);
+		else
+			alias getCType = void*;
+	}
+
+	unittest
+	{
+		import gobject.Value;
+
+		auto list = new ListSG(null);
+		list = list.append(new Value(0).getValueStruct());
+		list = list.append(new Value(1).getValueStruct());
+		auto arr = list.toArray!Value();
+
+		assert(arr[0].getInt() == 0);
+		assert(arr[1].getInt() == 1);
+
+		list = new ListSG(null);
+		list = list.append(cast(void*)"test\0".ptr);
+		list = list.append(cast(void*)"test2\0".ptr);
+
+		assert(["test", "test2"] == list.toArray!string());
+	}
+code: end
+
+struct: Spawn
+class: Spawn
+cType:
+import: core.thread
+import: core.stdc.string
+import: core.stdc.stdio
+import: std.string
+import: std.traits
+#noCode: spawn_async_with_pipes
+code: start
+	//we need fdopen.
+	version(Posix)
+	{
+		private import core.sys.posix.stdio;
+	}
+	//fdopen for Windows is defined in glib.c.types.
+
+	string workingDirectory = ".";
+	string[] argv;
+	string[] envp;
+	GSpawnFlags flags = SpawnFlags.SEARCH_PATH;
+	GSpawnChildSetupFunc childSetup;
+	void* userData;
+	GPid childPid;
+	FILE* standardInput;
+	FILE* standardOutput;
+	FILE* standardError;
+	GError* error;
+	int stdIn;
+	int stdOut;
+	int stdErr;
+
+	// for commandLineSync
+	int exitStatus;
+	char* strOutput;
+	char* strError;
+
+	alias bool delegate(Spawn) ChildWatch;
+	ChildWatch externalWatch;
+
+	/**
+	 * Creates a Spawn for execution.
+	 */
+	public this(string program, string[] envp=null)
+	{
+		argv ~= program;
+		this.envp = envp;
+	}
+
+	/**
+	 * Creates a Spawn for execution.
+	 */
+	public this(string[] program, string[] envp=null)
+	{
+		argv = program;
+		this.envp = envp;
+	}
+
+	/**
+	 * Adds a delegate to be notified on the end of the child process.
+	 * Params:
+	 *    	dlg =
+	 */
+	public void addChildWatch(ChildWatch dlg)
+	{
+		externalWatch = dlg;
+	}
+
+	/**
+	 * Closes all open streams and child process.
+	 */
+	public void close()
+	{
+		if (stdIn != 0 )
+		{
+			fclose(standardInput);
+			stdIn = 0;
+		}
+		if (stdOut != 0 )
+		{
+			fclose(standardOutput);
+			stdOut = 0;
+		}
+		if (stdErr != 0 )
+		{
+			fclose(standardError);
+			stdErr = 0;
+		}
+		static if ( isPointer!(GPid) )
+		{
+			if ( childPid !is null )
+			{
+				closePid(childPid);
+				childPid = null;
+			}
+		}
+		else
+		{
+			if ( childPid != 0 )
+			{
+				closePid(childPid);
+				childPid = 0;
+			}
+		}
+	}
+
+	/**
+	 * Adds a parameter to the execution program
+	 */
+	public void addParm(string parm)
+	{
+		argv ~= parm;
+	}
+
+	/**
+	 * Gets the last error message
+	 */
+	public string getLastError()
+	{
+		if ( error != null )
+		{
+			return Str.toString(error.message);
+		}
+		return "";
+	}
+
+	/**
+	 * Executes the prepared process
+	 */
+	public int execAsyncWithPipes(
+		ChildWatch externalWatch = null,
+		bool delegate(string) readOutput = null,
+		bool delegate(string) readError = null )
+	{
+		int result = g_spawn_async_with_pipes(
+		Str.toStringz(workingDirectory),
+		Str.toStringzArray(argv),
+		Str.toStringzArray(envp),
+		flags,
+		childSetup,
+		userData,
+		&childPid,
+		&stdIn,
+		&stdOut,
+		&stdErr,
+		&error
+		);
+
+		if ( result != 0 )
+		{
+			this.externalWatch = externalWatch;
+			g_child_watch_add(childPid, cast(GChildWatchFunc)(&childWatchCallback), cast(void*)this);
+			standardInput = fdopen(stdIn, Str.toStringz("w"));
+			standardOutput = fdopen(stdOut, Str.toStringz("r"));
+			standardError = fdopen(stdErr, Str.toStringz("r"));
+
+			if ( readOutput !is null )
+			{
+				(new ReadFile(standardOutput, readOutput)).start();
+			}
+			if ( readError !is null )
+			{
+				(new ReadFile(standardError, readError)).start();
+			}
+		}
+
+		return result;
+	}
+
+	class ReadFile : Thread
+	{
+		bool delegate(string) read;
+		FILE* file;
+
+		int lineCount;
+
+		this(FILE* file, bool delegate (string) read )
+		{
+			this.file = file;
+			this.read = read;
+
+			super(&run);
+		}
+
+		public void run()
+		{
+			string line = readLine(file);
+			while( line !is null )
+			{
+				++lineCount;
+				if ( read !is null )
+				{
+					read(line);
+				}
+				line = readLine(file);
+			}
+		}
+	}
+
+	private string readLine(FILE* stream, int max=4096)
+	{
+		if ( feof(stream) )
+		{
+			if ( externalWatch !is null )
+			{
+				externalWatch(this);
+			}
+			return null;
+		}
+		string line;
+		line.length = max+1;
+		char* lineP = fgets(Str.toStringz(line), max, stream);
+		if ( lineP is null )
+		{
+			return "";
+		}
+		size_t l = strlen(line.ptr);
+		if ( l > 0 ) --l;
+
+		return line[0..l];
+	}
+
+	extern(C) static void childWatchCallback(int pid, int status, Spawn spawn)
+	{
+		//writefln("Spawn.childWatchCallback %s %s", pid, status);
+		spawn.exitStatus = status;
+		if ( spawn.externalWatch !is null )
+		{
+			spawn.externalWatch(spawn);
+		}
+		spawn.close();
+	}
+
+
+	public bool endOfOutput()
+	{
+		if ( standardOutput is null ) return true;
+		return feof(standardOutput) != 0;
+	}
+
+	public bool endOfError()
+	{
+		if ( standardError is null ) return true;
+		return feof(standardError) != 0;
+	}
+
+	string getOutputString()
+	{
+		return Str.toString(strOutput);
+	}
+
+	string getErrorString()
+	{
+		return Str.toString(strError);
+	}
+
+	int getExitStatus()
+	{
+		return exitStatus;
+	}
+
+	/**
+	 * Executes a command synchronasly and
+	 * optionally calls delegates for sysout, syserr and end of job
+	 *
+	 */
+	public int commandLineSync(
+		ChildWatch externalWatch = null,
+		bool delegate(string) readOutput = null,
+		bool delegate(string) readError = null )
+	{
+		string commandLine;
+		foreach ( int count, string arg; argv)
+		{
+			if ( count > 0 )
+			{
+				commandLine ~= ' ';
+			}
+			commandLine ~= arg;
+		}
+		int status = g_spawn_command_line_sync(
+			Str.toStringz(commandLine),
+			&strOutput,
+			&strError,
+			&exitStatus,
+			&error);
+		if ( readOutput != null )
+		{
+			foreach ( string line ; splitLines(Str.toString(strOutput)) )
+			{
+				readOutput(line);
+			}
+		}
+		if ( readError != null )
+		{
+			foreach ( string line ; splitLines(Str.toString(strError)) )
+			{
+				readError(line);
+			}
+		}
+		if ( externalWatch != null )
+		{
+			externalWatch(this);
+		}
+		return status;
+	}
+code: end
+
+struct: Str
+import: core.stdc.stdio
+import: core.stdc.string
+import: gobject.c.types
+code: start
+	/*
+	 * Convert C-style 0 terminated string s to char[] string.
+	 * copied from phobos
+	 */
+	public static string toString(const(char)* s, size_t len = 0) pure
+	{
+		if ( s is null )
+			return cast(string)null;
+
+		if ( len == 0 )
+			len = strlen(s);
+
+		return s[0 .. len].idup;
+	}
+
+	/*
+	 * Convert array of chars s[] to a C-style 0 terminated string.
+	 * copied from phobos
+	 */
+	public static char* toStringz(string s) pure
+	{
+		if ( s is null ) return null;
+		char[] copy;
+
+		if (s.length == 0)
+		{
+			copy = "\0".dup;
+		}
+		else
+		{
+			// Need to make a copy
+			copy = new char[s.length + 1];
+			copy[0..s.length] = s[];
+			copy[s.length] = 0;
+		}
+
+		return copy.ptr;
+	}
+
+	/** */
+	public static char** toStringzArray(string[] args) pure
+	{
+		if ( args is null )
+		{
+			return null;
+		}
+		char** argv = (new char*[args.length]).ptr;
+		int argc = 0;
+		foreach (string p; args)
+		{
+			argv[argc++] = cast(char*)(p.dup~'\0');
+		}
+		argv[argc] = null;
+
+		return argv;
+	}
+
+	/** */
+	public static char*** toStringzArray(string[][] args) pure
+	{
+		if ( args is null )
+		{
+			return null;
+		}
+		char**[] argv = new char**[args.length];
+		int argc = 0;
+		foreach( string[] p; args )
+		{
+			argv[argc++] = toStringzArray(p);
+		}
+		argv[argc] = null;
+
+		return argv.ptr;
+	}
+
+	/** */
+	public static string[] toStringArray(const(char*)* args) pure
+	{
+		if ( args is null )
+		{
+			return null;
+		}
+		string[] argv;
+
+		while ( *args !is null )
+		{
+			argv ~= toString(*args);
+			args++;
+		}
+
+		return argv;
+	}
+
+	/** */
+	public static string[] toStringArray(const(char*)* args, size_t len) pure
+	{
+		string[] argv = new string[len];
+
+		for ( int i; i < len; i++ )
+		{
+			argv[i] = toString(args[i]);
+		}
+
+		return argv;
+	}
+
+	/** */
+	public static string[][] toStringArray(char*** args) pure
+	{
+		string[][] argv;
+
+		if ( args is null )
+		{
+			return null;
+		}
+
+		while ( *args !is null )
+		{
+			argv ~= toStringArray(*args);
+			args++;
+		}
+
+		return argv;
+	}
+
+	/** */
+	public static void freeString(char* str)
+	{
+		g_free(str);
+	}
+
+	/** */
+	public static void freeStringArray(char** str)
+	{
+		g_strfreev(str);
+	}
+
+	/** */
+	public static void freeStringArray(char*** str)
+	{
+		while ( *str !is null )
+		{
+			g_strfreev(*str);
+			str++;
+		}
+
+		g_free(str);
+	}
+code: end
+
+struct: String
+class: StringG
+
+struct: Thread
+noCode: new
+
+struct: Timeout
+class: Timeout
+cType:
+code: start
+	/** Holds all idle delegates */
+	private bool delegate()[] timeoutListeners;
+	/** Our timeout ID */
+	private uint timeoutID;
+
+
+	/**
+	 * Creates a new timeout cycle with the default priority, GPriority.DEFAULT.
+	 *
+	 * Note that timeout functions may be delayed, due to the processing of other
+	 * event sources. Thus they should not be relied on for precise timing.
+	 * After each call to the timeout function, the time of the next timeout is
+	 * recalculated based on the current time and the given interval
+	 * (it does not try to 'catch up' time lost in delays).
+	 * Params:
+	 *    	interval = 	the timeout in milieconds
+	 *    	delegate() = 	the delegate to be executed
+	 *    	fireNow = 	When true the delegate will be executed emmidiatly
+	 */
+	this(uint interval, bool delegate() dlg, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		timeoutListeners ~= dlg;
+		timeoutID = g_timeout_add_full(GPriority.DEFAULT, interval, cast(GSourceFunc)&timeoutCallback, cast(void*)this, cast(GDestroyNotify)&destroyTimeoutNotify);
+	}
+
+	/**
+	 * Creates a new timeout cycle.
+	 * Params:
+	 *    	interval = 	the timeout in milieconds
+	 *    	delegate() = 	the delegate to be executed
+	 *      priority = Priority for the timeout function
+	 *    	fireNow = 	When true the delegate will be executed emmidiatly
+	 */
+	this(uint interval, bool delegate() dlg, GPriority priority, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		timeoutListeners ~= dlg;
+		timeoutID = g_timeout_add_full(priority, interval, cast(GSourceFunc)&timeoutCallback, cast(void*)this, cast(GDestroyNotify)&destroyTimeoutNotify);
+	}
+
+	/**
+	 * Creates a new timeout cycle with the default priority, GPriority.DEFAULT.
+	 * Params:
+	 *    	delegate() = 	the delegate to be executed
+	 *      seconds = interval in seconds.
+	 *    	fireNow = 	When true the delegate will be executed emmidiatly
+	 */
+	this(bool delegate() dlg, uint seconds, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		timeoutListeners ~= dlg;
+		timeoutID = g_timeout_add_seconds_full(GPriority.DEFAULT, seconds, cast(GSourceFunc)&timeoutCallback, cast(void*)this, cast(GDestroyNotify)&destroyTimeoutNotify);
+	}
+
+	/**
+	 * Creates a new timeout cycle.
+	 * Params:
+	 *    	delegate() = 	the delegate to be executed
+	 *      seconds = interval in seconds.
+	 *      priority = Priority for the timeout function
+	 *    	fireNow = 	When true the delegate will be executed emmidiatly
+	 */
+	this(bool delegate() dlg, uint seconds, GPriority priority, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		timeoutListeners ~= dlg;
+		timeoutID = g_timeout_add_seconds_full(priority, seconds, cast(GSourceFunc)&timeoutCallback, cast(void*)this, cast(GDestroyNotify)&destroyTimeoutNotify);
+	}
+
+	/** Removes the timeout from gtk */
+	public void stop()
+	{
+		if ( timeoutID > 0 )
+		{
+			g_source_remove(timeoutID);
+		}
+	}
+
+	/**
+	 * Removes the timeout from gtk
+	 */
+	~this()
+	{
+		stop();
+	}
+
+	/**
+	 * Adds a new delegate to this timeout cycle
+	 * Params:
+	 *    	dlg =
+	 *    	fireNow =
+	 */
+	public void addListener(bool delegate() dlg, bool fireNow=false)
+	{
+		if ( fireNow && !dlg() )
+			return;
+
+		timeoutListeners ~= dlg;
+	}
+
+	/**
+	 * The callback execution from glib
+	 * Params:
+	 *    	timeout =
+	 * Returns:
+	 */
+	extern(C) static bool timeoutCallback(Timeout timeout)
+	{
+		bool runAgain = false;
+		int i = 0;
+
+		while ( i<timeout.timeoutListeners.length )
+		{
+			if ( !timeout.timeoutListeners[i]() )
+			{
+				timeout.timeoutListeners = timeout.timeoutListeners[0..i] ~ timeout.timeoutListeners[i+1..$];
+			}
+			else
+			{
+				runAgain = true;
+				++i;
+			}
+		}
+
+		return runAgain;
+	}
+
+	/*
+	 * Reset the timeout object when it's destroyed on the GTK side.
+	 */
+	extern(C) static void destroyTimeoutNotify(Timeout timeout)
+	{
+		timeout.timeoutListeners.length = 0;
+		timeout.timeoutID = 0;
+	}
+code: end
+
+struct: TimeZone
+noCode: new_local
+noCode: new_utc
+
+struct: Tree
+class: BBTree
+
+struct: Util
+move: build_filenamev Util
+move: build_pathv Util
+noCode: build_filenamev
+noCode: build_pathv
+code: start
+	/**
+	 * Behaves exactly like g_build_filename(), but takes the path elements
+	 * as a string array, instead of varargs. This function is mainly
+	 * meant for language bindings.
+	 *
+	 * Params:
+	 *     args = strings containing the path elements.
+	 *
+	 * Return: a newly-allocated string that must be freed with g_free().
+	 *
+	 * Since: 2.8
+	 */
+	public static string buildFilename(string[] firstElement ... )
+	{
+		return Str.toString(g_build_filenamev(Str.toStringzArray(firstElement)));
+	}
+
+	/**
+	 * Behaves exactly like g_build_path(), but takes the path elements
+	 * as a string array, instead of varargs. This function is mainly
+	 * meant for language bindings.
+	 *
+	 * Params:
+	 *     separator = a string used to separator the elements of the path.
+	 *     args = strings containing the path elements.
+	 *
+	 * Return: a newly-allocated string that must be freed with g_free().
+	 *
+	 * Since: 2.8
+	 */
+	public static string buildPath(string separator, string[] firstElement ... )
+	{
+		return Str.toString(g_build_pathv(Str.toStringz(separator), Str.toStringzArray(firstElement)));
+	}
+code: end
+
+struct: Variant
+noCode: new_bytestring_array
+noCode: new_object_path
+noCode: new_signature
+noCode: new_objv
+noCode: new_bytestring
+noCode: new_handle
+noCode: new_take_string
+code: start
+	/**
+	 * Creates a DBus object path GVariant with the contents of string.
+	 * string must be a valid DBus object path.
+	 * Use Variant.isObjectPath() if you're not sure.
+	 *
+	 * Since: 2.24
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static Variant fromObjectPath(string path)
+	{
+		auto p = g_variant_new_object_path(Str.toStringz(path));
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_variant_new_object_path");
+		}
+		return new Variant(cast(GVariant*) p);
+	}
+
+	/**
+	 * Creates a DBus type signature GVariant with the contents of string.
+	 * string must be a valid DBus type signature.
+	 * Use Variant.isSignature() if you're not sure.
+	 *
+	 * Since: 2.24
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static Variant fromSignature(string signature)
+	{
+		auto p = g_variant_new_signature(Str.toStringz(signature));
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_variant_new_signature");
+		}
+		return new Variant(cast(GVariant*) p);
+	}
+
+	/**
+	 * Creates an array-of-bytes GVariant with the contents of string.
+	 * This function is just like new Variant(string) except that the string
+	 * need not be valid utf8.
+	 *
+	 * The nul terminator character at the end of the string is stored in
+	 * the array.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static Variant fromByteString(string byteString)
+	{
+		auto p = g_variant_new_bytestring(Str.toStringz(byteString));
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_variant_new_bytestring");
+		}
+		return new Variant(cast(GVariant*) p);
+	}
+
+	/**
+	 * Constructs an array of object paths Variant from the given array
+	 * of strings.
+	 *
+	 * Each string must be a valid Variant object path.
+	 *
+	 * Since: 2.30
+	 *
+	 * Params:
+	 *     strv   = an array of strings.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static Variant fromObjv(string[] strv)
+	{
+		// GVariant * g_variant_new_objv (const gchar * const *strv,  gssize length);
+		auto p = g_variant_new_objv(Str.toStringzArray(strv), strv.length);
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_variant_new_objv(strv, length)");
+		}
+		return new Variant(cast(GVariant*) p);
+	}
+
+	/**
+	 * Constructs an array of bytestring GVariant from the given array of
+	 * strings. If length is -1 then strv is null-terminated.
+	 *
+	 * Since: 2.26
+	 *
+	 * Params:
+	 *     strv   = an array of strings.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static Variant fromByteStringArray(string[] strv)
+	{
+		auto p = g_variant_new_bytestring_array(Str.toStringzArray(strv), strv.length);
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_variant_new_bytestring_array(strv, length)");
+		}
+		return new Variant(cast(GVariant*) p);
+	}
+code: end
+
+struct: VariantType
+noCode: new_maybe
+code: start
+	/**
+	 * Constructs the type corresponding to a maybe instance containing
+	 * type type or Nothing.
+	 *
+	 * It is appropriate to call free() on the return value.
+	 *
+	 * Params:
+	 *     element = a VariantType
+	 *
+	 * Return: a new maybe VariantType
+	 *
+	 *     Since 2.24
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public static VariantType newMaybe(VariantType element)
+	{
+		auto p = g_variant_type_new_maybe((element is null) ? null : element.getVariantTypeStruct());
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by new_maybe");
+		}
+
+		return new VariantType(cast(GVariantType*) p);
+	}
+code: end
+
+struct:
+
+move: atomic_int_add Atomic int_add
+move: atomic_int_and Atomic int_and
+move: atomic_int_compare_and_exchange Atomic int_compare_and_exchange
+move: atomic_int_dec_and_test Atomic int_dec_and_test
+move: atomic_int_exchange_and_add Atomic int_exchange_and_add
+move: atomic_int_get Atomic int_get
+move: atomic_int_inc Atomic int_inc
+move: atomic_int_or Atomic int_or
+move: atomic_int_set Atomic int_set
+move: atomic_int_xor Atomic int_xor
+move: atomic_pointer_add Atomic pointer_add
+move: atomic_pointer_and Atomic pointer_and
+move: atomic_pointer_compare_and_exchange Atomic pointer_compare_and_exchange
+move: atomic_pointer_get Atomic pointer_get
+move: atomic_pointer_or Atomic pointer_or
+move: atomic_pointer_set Atomic pointer_set
+move: atomic_pointer_xor Atomic pointer_xor
+
+move: base64_decode Base64 decode
+move: base64_encode Base64 encode
+move: base64_encode_close Base64 encode_close
+move: base64_encode_step Base64 encode_step
+
+move: convert CharacterSet
+move: convert_error_quark CharacterSet
+move: convert_with_fallback CharacterSet
+move: convert_with_iconv CharacterSet
+move: filename_display_basename CharacterSet
+move: filename_display_name CharacterSet
+move: filename_from_utf8 CharacterSet
+move: filename_to_utf8 CharacterSet
+move: get_charset CharacterSet
+move: get_codeset CharacterSet
+move: get_filename_charsets CharacterSet
+move: locale_from_utf8 CharacterSet
+move: locale_to_utf8 CharacterSet
+
+move: child_watch_add Child
+move: child_watch_add_full Child
+move: child_watch_source_new Child
+
+move: compute_checksum_for_bytes Checksum
+move: compute_checksum_for_data Checksum
+move: compute_checksum_for_string Checksum
+
+move: datalist_clear DataList clear
+move: datalist_foreach DataList foreach
+move: datalist_get_data DataList get_data
+move: datalist_get_flags DataList get_flags
+move: datalist_id_dup_data DataList id_dup_data
+move: datalist_id_get_data DataList id_get_data
+move: datalist_id_remove_no_notify DataList id_remove_no_notify
+move: datalist_id_replace_data DataList id_replace_data
+move: datalist_id_set_data_full DataList id_set_data_full
+move: datalist_init DataList init
+move: datalist_set_flags DataList set_flags
+move: datalist_unset_flags DataList unset_flags
+
+move: dataset_destroy DataSet destroy
+move: dataset_foreach DataSet foreach
+move: dataset_id_get_data DataSet id_get_data
+move: dataset_id_remove_no_notify DataSet id_remove_no_notify
+move: dataset_id_set_data_full DataSet id_set_data_full
+
+#move: clear_error Error
+move: prefix_error Error
+move: propagate_prefixed_error Error
+move: set_error Error
+
+move: access FileUtils
+move: chdir FileUtils
+move: close FileUtils
+move: file_error_from_errno FileUtils
+move: file_error_quark FileUtils
+move: file_get_contents FileUtils
+move: file_open_tmp FileUtils
+move: file_read_link FileUtils
+move: file_set_contents FileUtils
+move: file_test FileUtils
+move: mkdir_with_parents FileUtils
+move: mkdtemp FileUtils
+move: mkdtemp_full FileUtils
+move: mkstemp FileUtils
+move: mkstemp_full FileUtils
+move: rmdir FileUtils
+move: unlink FileUtils
+
+move: direct_equal HashTable
+move: direct_hash HashTable
+move: double_equal HashTable
+move: double_hash HashTable
+move: int64_equal HashTable
+move: int64_hash HashTable
+move: int_equal HashTable
+move: int_hash HashTable
+move: str_equal HashTable
+move: str_hash HashTable
+
+move: hostname_is_ascii_encoded Hostname is_ascii_encoded
+move: hostname_is_ip_address Hostname is_ip_address
+move: hostname_is_non_ascii Hostname is_non_ascii
+move: hostname_to_ascii Hostname to_ascii
+move: hostname_to_unicode Hostname to_unicode
+
+move: idle_add Idle add
+move: idle_add_full Idle add_full
+move: idle_remove_by_data Idle remove_by_data
+move: idle_source_new Idle source_new
+
+move: dcgettext Internationalization
+move: dgettext Internationalization
+move: dngettext Internationalization
+move: dpgettext Internationalization
+move: dpgettext2 Internationalization
+move: get_language_names Internationalization
+move: get_locale_variants Internationalization
+move: strip_context Internationalization
+
+move: io_add_watch IOChannel
+move: io_add_watch_full IOChannel
+move: io_create_watch IOChannel
+
+move: main_current_source MainLoop
+move: main_depth MainLoop
+move: poll MainLoop
+
+move: markup_collect_attributes MarkupParseContext
+move: markup_error_quark MarkupParseContext
+move: markup_escape_text MarkupParseContext
+move: markup_printf_escaped MarkupParseContext
+move: markup_vprintf_escaped MarkupParseContext
+
+move: clear_pointer Memory
+move: free Memory
+move: malloc Memory
+move: malloc0 Memory
+move: malloc0_n Memory
+move: malloc_n Memory
+move: mem_is_system_malloc Memory
+move: mem_profile Memory
+move: mem_set_vtable Memory
+move: memdup Memory
+move: realloc Memory
+move: realloc_n Memory
+move: try_malloc Memory
+move: try_malloc0 Memory
+move: try_malloc0_n Memory
+move: try_malloc_n Memory
+move: try_realloc Memory
+move: try_realloc_n Memory
+
+move: slice_alloc MemorySlice
+move: slice_alloc0 MemorySlice
+move: slice_copy MemorySlice
+move: slice_free1 MemorySlice
+move: slice_free_chain_with_offset MemorySlice
+move: slice_get_config MemorySlice
+move: slice_get_config_state MemorySlice
+move: slice_set_config MemorySlice
+
+move: log MessageLog
+move: log_default_handler MessageLog
+move: log_remove_handler MessageLog
+move: log_set_always_fatal MessageLog
+move: log_set_default_handler MessageLog
+move: log_set_fatal_mask MessageLog
+move: log_set_handler MessageLog
+move: log_set_handler_full MessageLog
+move: logv MessageLog
+
+move: on_error_query Messages
+move: on_error_stack_trace Messages
+move: print Messages
+move: printerr Messages
+move: set_print_handler Messages
+move: set_printerr_handler Messages
+
+move: option_error_quark OptionContext
+
+move: pattern_match PatternSpec
+move: pattern_match_simple PatternSpec
+move: pattern_match_string PatternSpec
+
+move: intern_static_string Quark
+move: intern_string Quark
+move: quark_from_static_string Quark
+move: quark_from_string Quark
+move: quark_to_string Quark
+move: quark_try_string Quark
+
+move: random_double Rand
+move: random_double_range Rand
+move: random_int Rand
+move: random_int_range Rand
+move: random_set_seed Rand
+
+move: shell_error_quark ShellUtils
+move: shell_parse_argv ShellUtils
+move: shell_quote ShellUtils
+move: shell_unquote ShellUtils
+
+move: spawn_async Spawn async
+move: spawn_async_with_pipes Spawn async_with_pipes
+move: spawn_check_exit_status Spawn check_exit_status
+move: spawn_close_pid Spawn close_pid
+move: spawn_command_line_async Spawn command_line_async
+move: spawn_command_line_sync Spawn command_line_sync
+move: spawn_error_quark Spawn error_quark
+move: spawn_exit_error_quark Spawn exit_error_quark
+move: spawn_sync Spawn sync
+
+struct: Spawn
+noCode: async_with_pipes
+
+move: ascii_digit_value Str
+move: ascii_dtostr Str
+move: ascii_formatd Str
+move: ascii_strcasecmp Str
+move: ascii_strdown Str
+move: ascii_strncasecmp Str
+move: ascii_strtod Str
+move: ascii_strtoll Str
+move: ascii_strtoull Str
+move: ascii_strup Str
+move: ascii_tolower Str
+move: ascii_toupper Str
+move: ascii_xdigit_value Str
+move: printf Str
+move: printf_string_upper_bound Str
+move: snprintf Str
+move: sprintf Str
+move: stpcpy Str
+move: str_has_prefix Str has_prefix
+move: str_has_suffix Str has_suffix
+move: str_is_ascii Str is_ascii
+move: str_match_string Str match_string
+move: str_to_ascii Str to_ascii
+move: str_tokenize_and_fold Str tokenize_and_fold
+move: strcanon Str
+move: strcasecmp Str
+move: strchomp Str
+move: strchug Str
+move: strcmp0 Str
+move: strcompress Str
+move: strconcat Str
+move: strdelimit Str
+move: strdown Str
+move: strdup Str
+move: strdup_printf Str
+move: strdup_vprintf Str
+move: strdupv Str
+move: strerror Str
+move: strescape Str
+move: strfreev Str
+move: strjoin Str
+move: strjoinv Str
+move: strlcat Str
+move: strlcpy Str
+move: strncasecmp Str
+move: strndup Str
+move: strnfill Str
+move: strreverse Str
+move: strrstr Str
+move: strrstr_len Str
+move: strsignal Str
+move: strsplit Str
+move: strsplit_set Str
+move: strstr_len Str
+move: strtod Str
+move: strup Str
+move: strv_get_type Str
+move: strv_length Str
+move: strv_contains Str
+move: vasprintf Str
+move: vprintf Str
+move: vsnprintf Str
+move: vsprintf Str
+
+version !OSX: start
+	move: fprintf Str
+	move: vfprintf Str
+version: end
+
+version 2.54: start
+	move: ascii_string_to_signed Str
+	move: ascii_string_to_unsigned Str
+version: end
+
+move: string_new String
+move: string_new_len String
+move: string_sized_new String
+
+move: bit_lock Thread
+move: bit_trylock Thread
+move: bit_unlock Thread
+move: get_num_processors Thread
+move: pointer_bit_lock Thread
+move: pointer_bit_trylock Thread
+move: pointer_bit_unlock Thread
+
+move: timeout_add Timeout add
+move: timeout_add_full Timeout add_full
+move: timeout_add_seconds Timeout add_seconds
+move: timeout_add_seconds_full Timeout add_seconds_full
+move: timeout_source_new Timeout source_new
+move: timeout_source_new_seconds Timeout source_new_seconds
+
+move: get_current_time TimeVal
+move: get_monotonic_time TimeVal
+move: get_real_time TimeVal
+move: usleep TimeVal
+
+move: ucs4_to_utf16 Unicode
+move: ucs4_to_utf8 Unicode
+move: unichar_break_type Unicode
+move: unichar_combining_class Unicode
+move: unichar_compose Unicode
+move: unichar_decompose Unicode
+move: unichar_digit_value Unicode
+move: unichar_fully_decompose Unicode
+move: unichar_get_mirror_char Unicode
+move: unichar_get_script Unicode
+move: unichar_isalnum Unicode
+move: unichar_isalpha Unicode
+move: unichar_iscntrl Unicode
+move: unichar_isdefined Unicode
+move: unichar_isdigit Unicode
+move: unichar_isgraph Unicode
+move: unichar_islower Unicode
+move: unichar_ismark Unicode
+move: unichar_isprint Unicode
+move: unichar_ispunct Unicode
+move: unichar_isspace Unicode
+move: unichar_istitle Unicode
+move: unichar_isupper Unicode
+move: unichar_iswide Unicode
+move: unichar_iswide_cjk Unicode
+move: unichar_isxdigit Unicode
+move: unichar_iszerowidth Unicode
+move: unichar_to_utf8 Unicode
+move: unichar_tolower Unicode
+move: unichar_totitle Unicode
+move: unichar_toupper Unicode
+move: unichar_type Unicode
+move: unichar_validate Unicode
+move: unichar_xdigit_value Unicode
+move: unicode_canonical_decomposition Unicode
+move: unicode_canonical_ordering Unicode
+move: unicode_script_from_iso15924 Unicode
+move: unicode_script_to_iso15924 Unicode
+move: utf16_to_ucs4 Unicode
+move: utf16_to_utf8 Unicode
+move: utf8_casefold Unicode
+move: utf8_collate Unicode
+move: utf8_collate_key Unicode
+move: utf8_collate_key_for_filename Unicode
+move: utf8_find_next_char Unicode
+move: utf8_find_prev_char Unicode
+move: utf8_get_char Unicode
+move: utf8_get_char_validated Unicode
+move: utf8_normalize Unicode
+move: utf8_offset_to_pointer Unicode
+move: utf8_pointer_to_offset Unicode
+move: utf8_prev_char Unicode
+move: utf8_strchr Unicode
+move: utf8_strdown Unicode
+move: utf8_strlen Unicode
+move: utf8_strncpy Unicode
+move: utf8_strrchr Unicode
+move: utf8_strreverse Unicode
+move: utf8_strup Unicode
+move: utf8_substring Unicode
+move: utf8_to_ucs4 Unicode
+move: utf8_to_ucs4_fast Unicode
+move: utf8_to_utf16 Unicode
+move: utf8_validate Unicode
+version 2.52: move: utf8_make_valid Unicode
+
+version !Windows: start
+	move: unix_error_quark UnixUtils error_quark
+	move: unix_fd_add UnixUtils fd_add
+	move: unix_fd_add_full UnixUtils fd_add_full
+	move: unix_fd_source_new UnixUtils fd_source_new
+	move: unix_open_pipe UnixUtils open_pipe
+	move: unix_set_fd_nonblocking UnixUtils set_fd_nonblocking
+	move: unix_signal_add UnixUtils signal_add
+	move: unix_signal_add_full UnixUtils signal_add_full
+	move: unix_signal_source_new UnixUtils signal_source_new
+version: end
+
+move: filename_from_uri URI
+move: filename_to_uri URI
+move: uri_escape_string URI
+move: uri_list_extract_uris URI
+move: uri_parse_scheme URI
+move: uri_unescape_segment URI
+move: uri_unescape_string URI
+
+version 2.52: start
+	move: uuid_string_is_valid Uuid string_is_valid
+	move: uuid_string_random Uuid string_random
+version: end
+
+move: atexit Util
+move: basename Util
+move: bit_nth_lsf Util
+move: bit_nth_msf Util
+move: bit_storage Util
+move: build_path Util
+move: environ_getenv Util
+move: environ_setenv Util
+move: environ_unsetenv Util
+move: find_program_in_path Util
+move: format_size Util
+move: format_size_for_display Util
+move: format_size_full Util
+move: get_application_name Util
+move: get_environ Util
+move: get_current_dir Util
+move: get_home_dir Util
+move: get_host_name Util
+move: get_prgname Util
+move: get_real_name Util
+move: get_system_config_dirs Util
+move: get_system_data_dirs Util
+move: get_tmp_dir Util
+move: get_user_cache_dir Util
+move: get_user_config_dir Util
+move: get_user_data_dir Util
+move: get_user_name Util
+move: get_user_runtime_dir Util
+move: get_user_special_dir Util
+move: getenv Util
+move: listenv Util
+move: nullify_pointer Util
+move: parse_debug_string Util
+move: path_get_basename Util
+move: path_get_dirname Util
+move: path_is_absolute Util
+move: path_skip_root Util
+move: qsort_with_data Util
+move: reload_user_special_dirs_cache Util
+move: set_application_name Util
+move: set_prgname Util
+move: setenv Util
+move: spaced_primes_closest Util
+move: unsetenv Util
+
+move: check_version Version

--- a/wrap/APILookupGObject.txt
+++ b/wrap/APILookupGObject.txt
@@ -1,0 +1,1059 @@
+﻿# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: gobject
+file: GObject-2.0.gir
+
+noAlias: Type
+addEnums: start
+
+	/**
+	 * A value which represents the unique identifier of a registered type.
+	 */
+	enum GType : size_t
+	{
+		INVALID = 0<<2,
+		NONE = 1<<2,
+		INTERFACE = 2<<2,
+		CHAR = 3<<2,
+		UCHAR = 4<<2,
+		BOOLEAN = 5<<2,
+		INT = 6<<2,
+		UINT = 7<<2,
+		LONG = 8<<2,
+		ULONG = 9<<2,
+		INT64 = 10<<2,
+		UINT64 = 11<<2,
+		ENUM = 12<<2,
+		FLAGS = 13<<2,
+		FLOAT = 14<<2,
+		DOUBLE = 15<<2,
+		STRING = 16<<2,
+		POINTER = 17<<2,
+		BOXED = 18<<2,
+		PARAM = 19<<2,
+		OBJECT = 20<<2,
+		VARIANT = 21<<2,
+	}
+addEnums: end
+
+struct: CClosure
+class: CClosure
+import: glib.ConstructionException
+import: gobject.ObjectG
+noCode: new
+noCode: new_swap
+noCode: new_object
+noCode: new_object_swap
+code: start
+	/**
+	 * Creates a new closure which invokes callbackFunc with userData as
+	 * the last parameter.
+	 *
+	 * Params:
+	 *     callbackFunc = the function to invoke
+	 *     userData = user data to pass to callbackFunc
+	 *     destroyData = destroy notify to be called when userData is no longer used
+	 *     swap = if true invoce with usrData as the first parameter
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public this(GCallback callbackFunc, void* userData, GClosureNotify destroyData, bool swap)
+	{
+		GClosure* p;
+
+		if ( swap )
+			p = g_cclosure_new_swap(callbackFunc, userData, destroyData);
+		else
+			p = g_cclosure_new(callbackFunc, userData, destroyData);
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by new");
+		}
+
+		this(cast(GCClosure*) p);
+	}
+
+	/**
+	 * A variant of this() which uses object as userData and
+	 * calls ObjectG.watchClosure() on object and the created
+	 * closure. This function is useful when you have a callback closely
+	 * associated with a gobject.ObjectG, and want the callback to no longer run
+	 * after the object is is freed.
+	 *
+	 * Params:
+	 *     callbackFunc = the function to invoke
+	 *     object = a gobject.ObjectG.ObjectG to pass to callbackFunc
+	 *     swap = if true invoce with usrData as the first parameter
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 */
+	public this(GCallback callbackFunc, ObjectG object, bool swap)
+	{
+		GClosure* p;
+
+		if ( swap )
+			p = g_cclosure_new_object_swap(callbackFunc, (object is null) ? null : object.getObjectGStruct());
+		else
+			p = g_cclosure_new_object(callbackFunc, (object is null) ? null : object.getObjectGStruct());
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by new_object");
+		}
+
+		this(cast(GCClosure*) p);
+	}
+code: end
+
+struct: DClosure
+namespace:
+import: glib.Str
+import: glib.Variant
+import: gobject.c.functions
+import: gobject.c.types
+import: gobject.Closure
+import: gobject.ObjectG
+import: gobject.ParamSpec
+import: core.memory
+import: std.algorithm
+import: std.conv
+import: std.traits
+import: std.typecons
+code: start
+	struct DGClosure(T)
+	{
+		GClosure closure;
+
+		static if ( isDelegate!T )
+		{
+			DGClosureWrapDelegate!(T)* wrap;
+			alias wrap this;
+		}
+		else
+		{
+			T callback;
+		}
+	}
+
+	struct DGClosureWrapDelegate(T)
+	{
+		T callback;
+	}
+
+	/**
+	* DClosure is a wrapper around the gobject library's GClosure with special handling for marshalling D delegates and function pointers as callbacks.
+	*
+	* Closures are central to the concept of asynchronous signal delivery which is widely used throughout GTK+ and GNOME applications.
+	* A closure is an abstraction, a generic representation of a callback.
+	*/
+	class DClosure : Closure
+	{
+		/** Get the main Gtk struct */
+		public GClosure* getDClosureStruct(bool transferOwnership = false)
+		{
+			if (transferOwnership)
+				ownedRef = false;
+			return gClosure;
+		}
+
+		/**
+		* Sets our main struct and passes it to the parent class.
+		*/
+		public this (GClosure* gClosure, bool ownedRef = false)
+		{
+			super(gClosure, ownedRef);
+		}
+
+		/**
+		* Create a new Closure that will call `callback` when it's invoked.
+		*
+		* Params:
+		*     callback = a delegate or function to call when the DClosure is invoked.
+		*     swap     = Should the first and last parameter passed to the callback be swapped.
+		*                This is usefull when using the closure for a Signal, where the instance is
+		*                 the first parameter, but when using delegates it usually isn't used.
+		*/
+		this(T)(T callback, bool swap = false)
+			if ( isCallable!T )
+		{
+			GClosure* gClosure = g_closure_new_simple(DGClosure!(T).sizeof, null);
+			g_closure_ref(gClosure);
+			g_closure_sink(gClosure);
+			g_closure_set_marshal(gClosure, &d_closure_marshal!T);
+			if ( swap ) gClosure.derivativeFlag = true;
+
+			auto dClosure = cast(DGClosure!(T)*)gClosure;
+
+			static if ( isDelegate!T )
+			{
+				dClosure.wrap = new DGClosureWrapDelegate!T;
+				GC.addRoot(dClosure.wrap);
+				g_closure_add_finalize_notifier(gClosure, null, &d_finalize_nofify);
+			}
+
+			dClosure.callback = callback;
+			super(gClosure, true);
+		}
+
+		extern(C) static void d_finalize_nofify(void* data, GClosure* dClosure)
+		{
+			GC.removeRoot((cast(DGClosure!(void delegate())*)dClosure).wrap);
+		}
+
+		extern(C) static void d_closure_marshal(T)(GClosure* closure, GValue* return_value, uint n_param_values, /*const*/ GValue* param_values, void* invocation_hint, void* marshal_data)
+		{
+			DGClosure!(T)* cl = cast(DGClosure!(T)*)closure;
+
+			if ( Parameters!(T).length > n_param_values )
+				assert(false, "DClosure doesn't have enough parameters.");
+
+			if ( closure.derivativeFlag )
+			{
+				GValue[] swapped = new GValue[n_param_values];
+				swapped[0..n_param_values-1] = param_values[1..n_param_values];
+				swapped[n_param_values-1] = param_values[0];
+				param_values = swapped.ptr;
+			}
+
+			mixin(getCallbackCall!T());
+		}
+
+		private static string getCallbackCall(T)()
+		{
+			if (!__ctfe) assert(false);
+
+			string call;
+
+			alias Params = Parameters!T;
+			foreach ( param; Params )
+			{
+				static if ( __traits(compiles, TemplateOf!param) && __traits(isSame, TemplateOf!param, glib.c.types.Scoped) )
+					call ~= "import "~moduleName!(TemplateArgsOf!(param)[0])~";\n";
+				else static if ( is(param == class) || is(param == interface) || is(param == struct) || is(param == enum) )
+					call ~= "import "~moduleName!param~";\n";
+				else static if ( isPointer!param && ( is(PointerTarget!param == struct) || is(PointerTarget!param == enum)) )
+					//The moduleName template gives an forward reference error here.
+				call ~= "import "~fullyQualifiedName!param.findSplitAfter(".c.types")[0]~";\n";
+			}
+			alias Ret = ReturnType!T;
+			static if ( is(Ret == class) || is(Ret == interface) || is(Ret == struct) || is(Ret == enum) )
+				call ~= "import "~moduleName!Ret~";\n";
+			else static if ( isPointer!Ret && ( is(PointerTarget!Ret == struct) || is(PointerTarget!Ret == enum)) )
+				call ~= "import "~fullyQualifiedName!Ret.findSplitAfter(".c.types")[0]~";\n";
+
+			static if ( !is(Ret == void) )
+				call ~= "auto ret = ";
+			call ~= "cl.callback(";
+
+			foreach ( i, param; Params )
+			{
+				if ( i > 0 )
+					call ~= ", ";
+				call ~= getValue!param(i);
+			}
+			call ~= ");\n";
+
+			static if ( is(Ret == bool) )
+				call ~= "g_value_set_boolean(return_value, ret);";
+			else static if ( is(Ret == byte) )
+				call ~= "g_value_set_schar(return_value, ret);";
+			else static if ( is(Ret == ubyte) )
+				call ~= "g_value_set_uchar(return_value, ret);";
+			else static if ( is(Ret == int) )
+				call ~= "g_value_set_int(return_value, ret);";
+			else static if ( is(Ret == uint) )
+				call ~= "g_value_set_uint(return_value, ret);";
+			else static if ( is(Ret == long) )
+				call ~= "g_value_set_int64(return_value, ret);";
+			else static if ( is(Ret == ulong) )
+				call ~= "g_value_set_uint64(return_value, ret);";
+			else static if ( is(Ret == float) )
+				call ~= "g_value_set_float(return_value, ret);";
+			else static if ( is(Ret == double) )
+				call ~= "g_value_set_double(return_value, ret);";
+			else static if ( is(Ret == string) )
+				call ~= "g_value_set_string(return_value, Str.toStringz(ret));";
+			else static if ( is(Ret == string[]) )
+				call ~= "g_value_set_pointer(return_value, Str.toStringzArray(ret));";
+			else static if ( is(Ret == enum) )
+				call ~= "g_type_is_a(return_value.gType, GType.ENUM) ? g_value_set_enum(return_value, ret) : g_value_set_flags(return_value, ret);";
+			else static if ( isPointer!Ret )
+				call ~= "g_type_is_a(return_value.gType, GType.POINTER) ? g_value_set_pointer(return_value, ret) : (g_type_is_a(return_value.gType, GType.BOXED) ? g_value_set_boxed(return_value, ret) : g_value_set_object(return_value, ret));";
+			else static if ( is(Ret == interface) )
+				call ~= "g_value_set_object(return_value, (cast(ObjectG)ret).getObjectGStruct());";
+			else static if ( is(Ret == class) )
+			{
+				static if ( is(Ret == Variant) )
+					call ~= "g_value_set_variant(return_value, ret.getVariantStruct());";
+				else static if ( is(Ret == ParamSpec) )
+					call ~= "g_value_set_param(return_value, ret.getParamSpecStruct());";
+				else static if ( is(Ret : ObjectG) )
+					call ~= "g_value_set_object(return_value, ret.getObjectGStruct());";
+				else
+					call ~= "g_type_is_a(return_value.gType, GType.POINTER) ? g_value_set_pointer(return_value, ret.get"~Ret.stringof~"Struct()) : (g_type_is_a(return_value.gType, GType.BOXED) ? g_value_set_boxed(return_value, ret.get"~Ret.stringof~"Struct()) : g_value_set_object(return_value, ret.get"~Ret.stringof~"Struct()));";
+			}
+
+			return call;
+		}
+
+		private static string getValue(Param)(int index)
+		{
+			if (!__ctfe) assert(false);
+
+			static if ( is(Param == bool) )
+				return "g_value_get_boolean(&param_values["~to!string(index)~"]) != 0";
+			else static if ( is(Param == byte) )
+				return "g_value_get_schar(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == ubyte) )
+				return "g_value_get_uchar(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == int) )
+				return "g_value_get_int(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == uint) )
+				return "g_value_get_uint(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == long) )
+				return "g_value_get_int64(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == ulong) )
+				return "g_value_get_uint64(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == float) )
+				return "g_value_get_float(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == double) )
+				return "g_value_get_double(&param_values["~to!string(index)~"])";
+			else static if ( is(Param == string) )
+				return "Str.toString(g_value_get_string(&param_values["~to!string(index)~"]))";
+			else static if ( is(Param == string[]) )
+				return "Str.toStringArray(cast(const(char*)*)g_value_get_pointer(&param_values["~to!string(index)~"]))";
+			else static if ( is(Param == enum) )
+				return "cast("~fullyQualifiedName!Param~")(g_type_is_a(param_values["~to!string(index)~"].gType, GType.ENUM) ? g_value_get_enum(&param_values["~to!string(index)~"]) : g_value_get_flags(&param_values["~to!string(index)~"]))";
+			else static if ( isPointer!Param )
+				return "cast("~fullyQualifiedName!Param~")(g_type_is_a(param_values["~to!string(index)~"].gType, GType.POINTER) ? g_value_get_pointer(&param_values["~to!string(index)~"]) : (g_type_is_a(param_values["~to!string(index)~"].gType, GType.BOXED) ? g_value_get_boxed(&param_values["~to!string(index)~"]) : g_value_get_object(&param_values["~to!string(index)~"])))";
+			else static if ( __traits(compiles, TemplateOf!Param) && __traits(isSame, TemplateOf!Param, glib.c.types.Scoped) )
+				return "getScopedGobject!("~fullyQualifiedName!(TemplateArgsOf!(Param)[0])~")(cast(typeof("~fullyQualifiedName!(TemplateArgsOf!(Param)[0])~".tupleof[0]))(g_type_is_a(param_values["~to!string(index)~"].gType, GType.POINTER) ? g_value_get_pointer(&param_values["~to!string(index)~"]) : (g_type_is_a(param_values["~to!string(index)~"].gType, GType.BOXED) ? g_value_get_boxed(&param_values["~to!string(index)~"]) : g_value_get_object(&param_values["~to!string(index)~"]))))";
+			else static if ( is(Param == interface) )
+				return "ObjectG.getDObject!("~fullyQualifiedName!Param~")(cast(GObject*)g_value_get_object(&param_values["~to!string(index)~"]))";
+			else static if ( is(Param == class) )
+			{
+				static if ( is(Param == Variant) )
+					return "new Variant(g_value_get_variant(&param_values["~to!string(index)~"]))";
+				else static if ( is(Param== ParamSpec) )
+					return "new ParamSpec(g_value_get_param(&param_values["~to!string(index)~"]))";
+				else static if ( is(Param : ObjectG) )
+					return "ObjectG.getDObject!("~fullyQualifiedName!Param~")(cast(typeof("~fullyQualifiedName!Param~".tupleof[0]))g_value_get_object(&param_values["~to!string(index)~"]))";
+				else
+					return "ObjectG.getDObject!("~fullyQualifiedName!Param~")(cast(typeof("~fullyQualifiedName!Param~".tupleof[0]))(g_type_is_a(param_values["~to!string(index)~"].gType, GType.POINTER) ? g_value_get_pointer(&param_values["~to!string(index)~"]) : (g_type_is_a(param_values["~to!string(index)~"].gType, GType.BOXED) ? g_value_get_boxed(&param_values["~to!string(index)~"]) : g_value_get_object(&param_values["~to!string(index)~"]))))";
+			}
+		}
+	}
+code: end
+
+struct: Object
+import: core.memory
+import: gobject.Signals
+import: std.algorithm
+import: std.traits
+merge: InitiallyUnowned
+noSignal: notify
+move: clear_object Object
+inout: clear_object object_ptr
+
+code: start
+	protected bool isGcRoot;
+
+	/**
+	 * Sets our main struct and passes store it on the gobject.
+	 * Add a gabage collector root to the gtk+ struct so it doesn't get collect
+	 */
+	public this (GObject* gObject, bool ownedRef = false)
+	{
+		this.gObject = gObject;
+		if ( gObject !is  null )
+		{
+			setDataFull("GObject", cast(void*)this, cast(GDestroyNotify)&destroyNotify);
+			addToggleRef(cast(GToggleNotify)&toggleNotify, cast(void*)this);
+
+			//If the refCount is larger then 1 toggleNotify isn't called
+			if (gObject.refCount > 1 && !isGcRoot)
+			{
+				GC.addRoot(cast(void*)this);
+				isGcRoot = true;
+			}
+
+			//Remove the floating reference if there is one.
+			if ( isFloating() )
+			{
+				refSink();
+				unref();
+			}
+			//If we already owned this reference remove the one added by addToggleRef.
+			else if ( ownedRef )
+			{
+				unref();
+			}
+		}
+	}
+
+	extern(C)
+	{
+		static void destroyNotify(ObjectG obj)
+		{
+			if ( obj.isGcRoot )
+			{
+				GC.removeRoot(cast(void*)obj);
+				obj.isGcRoot = false;
+			}
+
+			if ( obj.gObject.refCount > 0 )
+				obj.removeToggleRef(cast(GToggleNotify)&toggleNotify, cast(void*)obj);
+
+			obj.gObject = null;
+		}
+
+		static void toggleNotify(ObjectG obj, GObject* object, int isLastRef)
+		{
+			if ( isLastRef && obj.isGcRoot )
+			{
+				GC.removeRoot(cast(void*)obj);
+				obj.isGcRoot = false;
+			}
+			else if ( !obj.isGcRoot )
+			{
+				GC.addRoot(cast(void*)obj);
+				obj.isGcRoot = true;
+			}
+		}
+	}
+
+	~this()
+	{
+		static if ( isPointer!(typeof(g_object_steal_data)) )
+			bool libLoaded = Linker.isLoaded(LIBRARY_GOBJECT);
+		else
+			enum libLoaded = true;
+
+		if ( libLoaded && gObject !is null )
+		{
+			// Remove the GDestroyNotify callback,
+			// for when the D object is destroyed before the C one.
+			g_object_steal_data(gObject, cast(char*)"GObject");
+
+			if ( isGcRoot )
+			{
+				GC.removeRoot(cast(void*)this);
+				isGcRoot = false;
+			}
+
+			g_object_remove_toggle_ref(gObject, cast(GToggleNotify)&toggleNotify, cast(void*)this);
+		}
+	}
+
+	/** */
+	T opCast(T)()
+	{
+		if ( !this )
+			return null;
+
+		static if ( is(T : ObjectG)
+			&& !is(T == interface)
+			&& is(typeof(new T(cast(typeof(T.tupleof[0]))gObject, false))) )
+		{
+			//If a regular cast works, return the result.
+			if ( auto r = cast(T)super )
+				return r;
+
+			//Prints a warning if the cast is invalid.
+			//g_type_check_instance_cast(cast(GTypeInstance*)gObject, T.getType());
+
+			//Can we cast this type to T.
+			if ( !g_type_is_a(gObject.gTypeInstance.gClass.gType, T.getType()) )
+				return null;
+
+			//Remove the GDestroyNotify callback for the original d object.
+			g_object_steal_data(gObject, "GObject");
+			//Remove the original object as a GC root if needed.
+			if ( isGcRoot )
+			{
+				GC.removeRoot(cast(void*)this);
+				isGcRoot = false;
+			}
+			//Add a reference for the original D object before we remove the toggle reference.
+			g_object_ref(gObject);
+			g_object_remove_toggle_ref(gObject, cast(GToggleNotify)&toggleNotify, cast(void*)this);
+
+			//The new object handles the memory management.
+			return new T(cast(typeof(T.tupleof[0]))gObject, false);
+		}
+		else static if ( is(T == interface)
+			&& hasStaticMember!(T, "getType")
+			&& is(ReturnType!(T.getType) == GType) )
+		{
+			//If a regular cast works, return the result.
+			if ( auto r = cast(T)super )
+				return r;
+
+			//Do we implement interface T.
+			if ( !g_type_is_a(gObject.gTypeInstance.gClass.gType, T.getType()) )
+				return null;
+
+			return getInterfaceInstance!T(gObject);
+		}
+		else
+			return cast(T)super;
+	}
+
+	unittest
+	{
+		ObjectG obj = null;
+		
+		assert( (cast(Binding)obj) is null );
+	}
+
+	/**
+	 * Gets a D Object from the objects table of associations.
+	 * Params:
+	 *  obj = GObject containing the associations.
+	 * Returns: the D Object if found, or a newly constructed object if no such Object exists.
+	 */
+	public static RT getDObject(T, RT=T, U)(U obj, bool ownedRef = false)
+	{
+		if ( obj is null )
+		{
+			return null;
+		}
+
+		static if ( is(T : ObjectG) && !is(RT == interface) )
+		{
+			auto p = g_object_get_data(cast(GObject*)obj, Str.toStringz("GObject"));
+
+			if ( p !is null )
+				return cast(RT)cast(ObjectG)p;
+			else
+				return new T(obj, ownedRef);
+		}
+		else static if ( is(RT == interface) && hasMember!(RT, "getType") && is(ReturnType!(RT.getType) == GType) )
+		{
+			auto p = g_object_get_data(cast(GObject*)obj, Str.toStringz("GObject"));
+
+			if ( p !is null )
+				return cast(RT)cast(ObjectG)p;
+			else
+				return getInterfaceInstance!RT(cast(GObject*)obj);
+		}
+		else
+		{
+			return new T(obj, ownedRef);
+		}
+	}
+
+	private static I getInterfaceInstance(I)(GObject* instance)
+	{
+		static class Impl: ObjectG, I
+		{
+			public this (GObject* gObject, bool ownedRef = false)
+			{
+				super(gObject, ownedRef);
+			}
+			
+			/** the main Gtk struct as a void* */
+			protected override void* getStruct()
+			{
+				return cast(void*)gObject;
+			}
+
+			// add the interface capabilities
+			mixin("import "~ moduleName!I[0..$-2] ~"T;import "~ moduleName!I ~"; mixin "~ __traits(identifier, I)[0..$-2] ~"T!("~__traits(identifier, Impl)~");");
+		}
+
+		ClassInfo ci = Impl.classinfo;
+		Impl iface;
+		void* p;
+
+		//Skip all the setup for the memory management,
+		//and only add an extra reference for the instance returned.
+		p = GC.malloc(ci.initializer.length, GC.BlkAttr.FINALIZE, ci);
+		p[0..ci.initializer.length] = ci.initializer;
+		iface = cast(Impl)p;
+		iface.gObject = instance;
+		iface.addToggleRef(cast(GToggleNotify)&toggleNotify, cast(void*)iface);
+
+		return iface;
+	}
+
+	/** */
+	public void setProperty(T)(string propertyName, T value)
+	{
+		setProperty(propertyName, new Value(value));
+	}
+
+	deprecated("Use the member function")
+	public static void unref(ObjectG obj)
+	{
+		obj.unref();
+	}
+
+	deprecated("Use the member function")
+	public static ObjectG doref(ObjectG obj)
+	{
+		return obj.doref();
+	}
+
+	/**
+	 * The notify signal is emitted on an object when one of its
+	 * properties has been changed. Note that getting this signal
+	 * doesn't guarantee that the value of the property has actually
+	 * changed, it may also be emitted when the setter for the property
+	 * is called to reinstate the previous value.
+	 *
+	 * This signal is typically used to obtain change notification for a
+	 * single property.
+	 *
+	 * It is important to note that you must use
+	 * canonical parameter names for the property.
+	 *
+	 * Params:
+	 *     dlg          = The callback.
+	 *     property     = Set this if you only want to receive the signal for a specific property.
+	 *     connectFlags = The behavior of the signal's connection.
+	 */	
+	gulong addOnNotify(void delegate(ParamSpec, ObjectG) dlg, string property = "", ConnectFlags connectFlags=cast(ConnectFlags)0)
+	{
+		string signalName;
+
+		if ( property == "" )
+			signalName = "notify";
+		else
+			signalName = "notify::"~ property;
+
+		return Signals.connect(this, signalName, dlg, connectFlags ^ ConnectFlags.SWAPPED);
+	}
+code: end
+
+struct: ObjectClass
+merge: InitiallyUnownedClass
+
+struct: ParamSpecBoolean
+noCode: true
+
+struct: ParamSpecBoxed
+noCode: true
+
+struct: ParamSpecChar
+noCode: true
+
+struct: ParamSpecDouble
+noCode: true
+
+struct: ParamSpecEnum
+noCode: true
+
+struct: ParamSpecFlags
+noCode: true
+
+struct: ParamSpecFloat
+noCode: true
+
+struct: ParamSpecGType
+noCode: true
+
+struct: ParamSpecInt
+noCode: true
+
+struct: ParamSpecInt64
+noCode: true
+
+struct: ParamSpecLong
+noCode: true
+
+struct: ParamSpecObject
+noCode: true
+
+struct: ParamSpecOverride
+noCode: true
+
+struct: ParamSpecParam
+noCode: true
+
+struct: ParamSpecPointer
+noCode: true
+
+struct: ParamSpecString
+noCode: true
+
+struct: ParamSpecUChar
+noCode: true
+
+struct: ParamSpecUInt
+noCode: true
+
+struct: ParamSpecUInt64
+noCode: true
+
+struct: ParamSpecULong
+noCode: true
+
+struct: ParamSpecUnichar
+noCode: true
+
+struct: ParamSpecValueArray
+noCode: true
+
+struct: ParamSpecVariant
+noCode: true
+
+struct: Signals
+import: gobject.DClosure
+import: std.traits
+code: start
+	/**
+	 * Connects a callback to a signal for a particular object.
+	 *
+	 * The handler will be called before the default handler of the signal.
+	 *
+	 * Params:
+	 *     instance       = the instance to connect to.
+	 *     detailedSignal = a string of the form "signal-name::detail".
+	 *     callback       = the callback to connect.
+	 *     connectFlags   = a combination of ConnectFlags.
+	 *
+	 * Returns: the handler ID, of type gulong (always greater than 0 for successful connections)
+	 */
+	public static gulong connect(T)(ObjectG instance, string detailedSignal, T callback, ConnectFlags connectFlags = cast(ConnectFlags)0)
+		if ( isCallable!T && !is(T == GCallback) )
+	{
+		bool after = (connectFlags & ConnectFlags.AFTER) != false;
+		bool swap = (connectFlags & ConnectFlags.SWAPPED) != false;
+
+		return Signals.connectClosure(instance, detailedSignal, new DClosure(callback, swap), after);
+	}
+
+	deprecated public static gulong connectData(void* instanc, string detailedSignal, GCallback cHandler, Object data, GClosureNotify destroyData, GConnectFlags connectFlags)
+	{
+		return g_signal_connect_data(instanc, Str.toStringz(detailedSignal), cHandler, cast(void*)data, destroyData, connectFlags);
+	}
+
+	/**
+	 * Connects a GCallback function to a signal for a particular object.
+	 * 
+	 * The handler will be called before the default handler of the signal.
+	 *
+	 * See [memory management of signal handlers][signal-memory-management] for
+	 * details on how to handle the return value and memory management of @data.
+	 * 
+	 * Params:
+	 *     instance       = the instance to connect to.
+	 *     detailedSignal = a string of the form "signal-name::detail".
+	 *     cHandler       = the GCallback to connect.
+	 *     data           = data to pass to cHandler calls.
+	 *
+	 * Returns: the handler ID, of type gulong (always greater than 0 for successful connections)
+	 */
+	public static gulong connect(ObjectG instanc, string detailedSignal, GCallback cHandler, void* data)
+	{
+		return g_signal_connect_data((instanc is null) ? null : instanc.getObjectGStruct(), Str.toStringz(detailedSignal), cHandler, data, null, cast(ConnectFlags)0);
+	}
+code: end
+
+struct: Type
+import: gobject.ObjectG
+code: start
+	public static T* getInstanceClass(T)(ObjectG obj)
+	{
+		return cast(T*) (cast(GTypeInstance*)obj.getObjectGStruct()).gClass;
+	}
+
+	/**
+	 * Get the unique name that is assigned to the Objects type.
+	 * Returns: Static type name or NULL.
+	 */
+	public static string name(ObjectG obj)
+	{
+		GType type = (cast(GTypeInstance*)obj.getObjectGStruct()).gClass.gType;
+
+		return name(type);
+	}
+code: end
+
+struct: Value
+import: gobject.Type
+import: std.traits
+code: start
+	/** */
+	public this()
+	{
+		this(new GValue);
+	}
+
+	/** */
+	this(GOBJECT)(GOBJECT obj)
+		if ( is(GOBJECT == class) && hasMember!(GOBJECT, "getType") )
+	{
+		this();
+		init(GOBJECT.getType());
+
+		static if ( is(GOBJECT : ObjectG) )
+		{
+			setObject(obj);
+		}
+		else
+		{
+			if ( Type.isA(gValue.gType, GType.BOXED) )
+				setBoxed(obj.tupleof[0]);
+			else
+				setPointer(obj.tupleof[0]);
+		}
+	}
+
+
+	/** */
+	this(string value)
+	{
+		this();
+		init(GType.STRING);
+		setString(value);
+	}
+
+	/** */
+	this(BOOL)(BOOL value)
+		if( isBoolean!BOOL )
+	{
+		this();
+		init(GType.BOOLEAN);
+		setBoolean(value);
+	}
+
+	/** */
+	this(INT)(INT value)
+		if ( isIntegral!INT )
+	{
+		this();
+
+		static if ( is(OriginalType!INT == int) )
+		{
+			init(GType.INT);
+			setInt(value);
+		}
+		else static if ( is(OriginalType!INT == uint) )
+		{
+			init(GType.UINT);
+			setUint(value);
+		}
+		else static if ( is(OriginalType!INT == long) )
+		{
+			init(GType.INT64);
+			setInt64(value);
+		}
+		else static if ( is(OriginalType!INT == ulong) )
+		{
+			init(GType.UINT64);
+			setUint64(value);
+		}
+		else
+		{
+			init(GType.INT);
+			setInt(value);
+		}
+	}
+
+	/** */
+	this(FLOAT)(FLOAT value)
+		if ( isFloatingPoint!FLOAT )
+	{
+		this();
+
+		static if ( is( FLOAT == float ) )
+		{
+			init(GType.FLOAT);
+			setFloat(value);
+		}
+		else
+		{
+			init(GType.DOUBLE);
+			setDouble(value);
+		}
+	}
+code: end
+
+struct: WeakRef
+code: start
+	/** */
+	this(void* object)
+	{
+		g_weak_ref_init(gWeakRef, object);
+	}
+code: end
+
+#
+# Move functions defined as global into there respective classes
+#
+
+struct:
+
+move: boxed_copy Boxed copy
+move: boxed_free Boxed free
+move: boxed_type_register_static Boxed type_register_static
+move: pointer_type_register_static Boxed
+
+move: enum_complete_type_info Enums complete_type_info
+move: enum_get_value Enums get_value
+move: enum_get_value_by_name Enums get_value_by_name
+move: enum_get_value_by_nick Enums get_value_by_nick
+move: enum_register_static Enums register_static
+
+version 2.54: start
+	move: enum_to_string Enums
+	move: flags_to_string Enums
+version: end
+
+move: flags_complete_type_info Flags complete_type_info
+move: flags_get_first_value Flags get_first_value
+move: flags_get_value_by_name Flags get_value_by_name
+move: flags_get_value_by_nick Flags get_value_by_nick
+move: flags_register_static Flags register_static
+
+# ParamSpec Constructors?
+move: param_spec_boolean Value
+move: param_spec_boxed Value
+move: param_spec_char Value
+move: param_spec_double Value
+move: param_spec_enum Value
+move: param_spec_flags Value
+move: param_spec_float Value
+move: param_spec_gtype Value
+move: param_spec_int Value
+move: param_spec_int64 Value
+move: param_spec_long Value
+move: param_spec_object Value
+move: param_spec_override Value
+move: param_spec_param Value
+move: param_spec_pointer Value
+move: param_spec_string Value
+move: param_spec_uchar Value
+move: param_spec_uint Value
+move: param_spec_uint64 Value
+move: param_spec_ulong Value
+move: param_spec_unichar Value
+move: param_spec_value_array Value
+move: param_spec_variant Value
+
+move: param_type_register_static ParamSpec
+move: param_value_convert ParamSpec
+move: param_value_defaults ParamSpec
+move: param_value_set_default ParamSpec
+move: param_value_validate ParamSpec
+move: param_values_cmp ParamSpec
+
+move: signal_accumulator_first_wins Signals accumulator_first_wins
+move: signal_accumulator_true_handled Signals accumulator_true_handled
+move: signal_add_emission_hook Signals add_emission_hook
+move: signal_chain_from_overridden Signals chain_from_overridden
+move: signal_chain_from_overridden_handler Signals chain_from_overridden_handler
+move: signal_connect_closure Signals connect_closure
+move: signal_connect_closure_by_id Signals connect_closure_by_id
+move: signal_connect_data Signals connect_data
+move: signal_connect_object Signals connect_object
+move: signal_emit Signals emit
+move: signal_emit_by_name Signals emit_by_name
+move: signal_emit_valist Signals emit_valist
+move: signal_emitv Signals emitv
+move: signal_get_invocation_hint Signals get_invocation_hint
+move: signal_handler_block Signals handler_block
+move: signal_handler_disconnect Signals handler_disconnect
+move: signal_handler_find Signals handler_find
+move: signal_handler_is_connected Signals handler_is_connected
+move: signal_handler_unblock Signals handler_unblock
+move: signal_handlers_block_matched Signals handlers_block_matched
+move: signal_handlers_destroy Signals handlers_destroy
+move: signal_handlers_disconnect_matched Signals handlers_disconnect_matched
+move: signal_handlers_unblock_matched Signals handlers_unblock_matched
+move: signal_has_handler_pending Signals has_handler_pending
+move: signal_list_ids Signals list_ids
+move: signal_lookup Signals lookup
+move: signal_name Signals name
+move: signal_new Signals new
+move: signal_new_class_handler Signals new_class_handler
+move: signal_new_valist Signals new_valist
+move: signal_newv Signals newv
+move: signal_override_class_closure Signals override_class_closure
+move: signal_override_class_handler Signals override_class_handler
+move: signal_parse_name Signals parse_name
+move: signal_query Signals query
+move: signal_remove_emission_hook Signals remove_emission_
+move: signal_set_va_marshaller Signals set_va_marshaller
+move: signal_stop_emission Signals stop_emission
+move: signal_stop_emission_by_name Signals stop_emission_by_name
+move: signal_type_cclosure_new Signals type_cclosure_new
+
+move: source_set_closure Closure
+move: source_set_dummy_callback Closure
+
+move: strdup_value_contents Value
+
+move: type_add_class_cache_func Type add_class_cache_func
+move: type_add_class_private Type add_class_private
+move: type_add_instance_private Type add_instance_private
+move: type_add_interface_check Type add_interface_check
+move: type_add_interface_dynamic Type add_interface_dynamic
+move: type_add_interface_static Type add_interface_static
+move: type_check_class_cast Type check_class_cast
+move: type_check_class_is_a Type check_class_is_a
+move: type_check_instance Type check_instance
+move: type_check_instance_cast Type check_instance_cast
+move: type_check_instance_is_a Type check_instance_is_a
+move: type_check_instance_is_fundamentally_a Type check_instance_is_fundamentally_a
+move: type_check_is_value_type Type check_is_value_type
+move: type_check_value Type check_value
+move: type_check_value_holds Type check_value_holds
+move: type_children Type children
+move: type_create_instance Type create_instance
+move: type_default_interface_peek Type default_interface_peek
+move: type_default_interface_ref Type default_interface_ref
+move: type_default_interface_unref Type default_interface_unref
+move: type_depth Type depth
+move: type_ensure Type ensure
+move: type_free_instance Type free_instance
+move: type_from_name Type from_name
+move: type_fundamental Type fundamental
+move: type_fundamental_next Type fundamental_next
+move: type_get_plugin Type get_plugin
+move: type_get_qdata Type get_qdata
+move: type_get_type_registration_serial Type get_type_registration_serial
+move: type_init Type init
+move: type_init_with_debug_flags Type init_with_debug_flags
+move: type_interfaces Type interfaces
+move: type_is_a Type is_a
+move: type_name Type name
+move: type_name_from_class Type name_from_class
+move: type_name_from_instance Type name_from_instance
+move: type_next_base Type next_base
+move: type_parent Type parent
+move: type_qname Type qname
+move: type_query Type query
+move: type_register_dynamic Type register_dynamic
+move: type_register_fundamental Type register_fundamental
+move: type_register_static Type register_static
+move: type_register_static_simple Type register_static_simple
+move: type_remove_class_cache_func Type remove_class_cache_func
+move: type_remove_interface_check Type remove_interface_check
+move: type_set_qdata Type set_qdata
+move: type_test_flags Type test_flags
+move: type_get_instance_count Type get_instance_count
+#move: type_value_table_peek Type value_table_peek

--- a/wrap/APILookupGThread.txt
+++ b/wrap/APILookupGThread.txt
@@ -1,0 +1,65 @@
+﻿# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: gthread
+
+struct: Cond
+namespace:
+code: start
+	public  import glib.Cond;
+code: end
+
+struct: Mutex
+namespace:
+code: start
+	public  import glib.Mutex;
+code: end
+
+struct: Once
+namespace:
+code: start
+	public  import glib.Once;
+code: end
+
+struct: Private
+namespace:
+code: start
+	public  import glib.Private;
+code: end
+
+struct: RecMutex
+namespace:
+code: start
+	public  import glib.RecMutex;
+code: end
+
+struct: RWLock
+namespace:
+code: start
+	public  import glib.RWLock;
+code: end
+
+struct: Thread
+namespace:
+code: start
+	public  import glib.Thread;
+code: end

--- a/wrap/APILookupGio.txt
+++ b/wrap/APILookupGio.txt
@@ -1,0 +1,559 @@
+﻿# This file is part of gtkD.
+#
+# gtkD is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# gtkD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with gtkD; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+#############################################
+### Definitions for wrapping Gtk+ ###########
+#############################################
+
+# must start with wrap
+wrap: gio
+file: Gio-2.0.gir
+
+struct: Application
+code: start
+	/**
+	 * The ::command-line signal is emitted on the primary instance when
+	 * a commandline is not handled locally. See g_application_run() and
+	 * the #GApplicationCommandLine documentation for more information.
+	 *
+	 * Params:
+	 *     commandLine = a #GApplicationCommandLine representing the
+	 *         passed commandline
+	 *
+	 * Return: An integer that is set as the exit status for the calling
+	 *     process. See g_application_command_line_set_exit_status().
+	 */
+	gulong addOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	{
+		return Signals.connect(this, "command-line", dlg, connectFlags ^ ConnectFlags.SWAPPED);
+	}
+
+	/**
+	 * The ::open signal is emitted on the primary instance when there are
+	 * files to open. See g_application_open() for more information.
+	 *
+	 * Params:
+	 *     files = an array of #GFiles
+	 *     nFiles = the length of @files
+	 *     hint = a hint provided by the calling instance
+	 */
+	gulong addOnOpen(void delegate(FileIF[], string, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	{
+		return Signals.connect(this, "open", delegate void (GFile* gfiles, int nFiles, string hint, Application app){
+				FileIF[] files = new FileIF[nFiles];
+				for(int i = 0; i < nFiles; i++)
+				{
+					files[i] = ObjectG.getDObject!FileIF((cast(GFile**)gfiles)[i]);
+				}
+				dlg(files, hint, app);
+			}, connectFlags ^ ConnectFlags.SWAPPED);
+	}
+code: end
+
+struct: BufferedInputStream
+noCode: peek_buffer
+code: start
+	/**
+	 * Returns the buffer with the currently available bytes. The returned
+	 * buffer must not be modified and will become invalid when reading from
+	 * the stream or filling the buffer.
+	 *
+	 * Params:
+	 *     count = a #gsize to get the number of bytes available in the buffer
+	 *
+	 * Return: read-only buffer
+	 */
+	public ubyte[] peekBuffer()
+	{
+		size_t count;
+
+		auto p = g_buffered_input_stream_peek_buffer(gBufferedInputStream, &count);
+
+		return (cast(ubyte*)p)[0 .. count];
+	}
+code: end
+
+struct: DataInputStream
+noCode: read_byte
+
+struct: DBusActionGroup
+import: glib.ConstructionException
+code: start
+	/**
+	 * See_Also: get().
+	 */
+	this(DBusConnection connection, string busName, string objectPath)
+	{
+		auto p =  g_dbus_action_group_get((connection is null) ? null : connection.getDBusConnectionStruct(), Str.toStringz(busName), Str.toStringz(objectPath));
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_dbus_action_group_get");
+		}
+		this(cast(GDBusActionGroup*) p, true);
+	}
+code: end
+
+struct: DBusAnnotationInfo
+import: glib.Str
+noCode: lookup
+code: start
+	/**
+	 * Looks up the value of an annotation.
+	 *
+	 * The cost of this function is O(n) in number of annotations.
+	 *
+	 * Params:
+	 *     annotations = A %NULL-terminated array of annotations or %NULL.
+	 *     name = The name of the annotation to look up.
+	 *
+	 * Return: The value or %NULL if not found. Do not free, it is owned by @annotations.
+	 *
+	 * Since: 2.26
+	 */
+	public static string lookup(DBusAnnotationInfo[] annotations, string name)
+	{
+		GDBusAnnotationInfo*[] annotationsArray = new GDBusAnnotationInfo*[annotations.length+1];
+		for ( int i = 0; i < annotations.length ; i++ )
+		{
+			annotationsArray[i] = annotations[i].getDBusAnnotationInfoStruct();
+		}
+		annotationsArray[$-1] = null;
+
+		return Str.toString(g_dbus_annotation_info_lookup(annotationsArray.ptr, Str.toStringz(name)));
+	}
+code: end
+
+struct: DBusConnection
+alias: new newConnection
+noCode: new_finish
+noCode: new_for_address_finish
+code: start
+	/**
+	 * Finishes an operation started with g_dbus_connection_new().
+	 *
+	 * Params:
+	 *     res    = A GAsyncResult obtained from the GAsyncReadyCallback
+	 *               passed to g_dbus_connection_new().
+	 *     address = If true finish an address.
+	 *
+	 * Throws: GException on failure.
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.26
+	 */
+	public this (AsyncResultIF res, bool address = false)
+	{
+		GError* err = null;
+		GDBusConnection* p;
+
+		if ( address )
+		{
+			p = g_dbus_connection_new_for_address_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+		else
+		{
+			p = g_dbus_connection_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+
+		if (err !is null)
+		{
+			throw new GException( new ErrorG(err) );
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_dbus_connection_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err)");
+		}
+		this(p, true);
+	}
+code: end
+
+struct: DBusMenuModel
+import: glib.ConstructionException
+code: start
+	/**
+	 * See_Also: get().
+	 */
+	this(DBusConnection connection, string busName, string objectPath)
+	{
+		auto p =  g_dbus_menu_model_get((connection is null) ? null : connection.getDBusConnectionStruct(), Str.toStringz(busName), Str.toStringz(objectPath));
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_dbus_menu_model_get");
+		}
+
+		this(cast(GDBusMenuModel*) p, true);
+	}
+code: end
+
+struct: DBusObjectManagerClient
+alias: new newObjectManagerClient
+noCode: new_finish
+noCode: new_for_bus_finish
+code: start
+	/**
+	 * Finishes an operation started with g_dbus_object_manager_client_new().
+	 *
+	 * Params:
+	 *     res    = A GAsyncResult obtained from the GAsyncReadyCallback passed to the DBusObjectManager constructor.
+	 *     forBus = If true finish an address.
+	 *
+	 * Throws: GException on failure.
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.30
+	 */
+	public this (AsyncResultIF res, bool forBus = false)
+	{
+		GError* err = null;
+		GDBusObjectManager* p;
+
+		if ( forBus )
+		{
+			p = g_dbus_object_manager_client_new_for_bus_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+		else
+		{
+			p = g_dbus_object_manager_client_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+
+		if (err !is null)
+		{
+			throw new GException( new ErrorG(err) );
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_dbus_object_manager_client_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err)");
+		}
+		this(cast(GDBusObjectManagerClient*) p, true);
+	}
+code: end
+
+struct: DBusProxy
+alias: new newProxy
+noCode: new_finish
+noCode: new_for_bus_finish
+code: start
+	/**
+	 * Finishes creating a GDBusProxy.
+	 *
+	 * Params:
+	 *     res    = A GAsyncResult obtained from the GAsyncReadyCallback
+	 *              function passed to g_dbus_proxy_new().
+	 *     forBus = If true finish an address.
+	 *
+	 * Throws: GException on failure.
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.26
+	 */
+	public this (AsyncResultIF res, bool forBus = false)
+	{
+		GError* err = null;
+		GDBusProxy* p;
+
+		if ( forBus )
+		{
+			p = g_dbus_proxy_new_for_bus_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+		else
+		{
+			p = g_dbus_proxy_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err);
+		}
+
+		if (err !is null)
+		{
+			throw new GException( new ErrorG(err) );
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_dbus_proxy_new_finish((res is null) ? null : res.getAsyncResultStruct(), &err)");
+		}
+		this(p, true);
+	}
+code: end
+
+version !Windows: start
+	struct: DesktopAppInfo
+	noCode: new_from_filename
+	code: start
+		/**
+		* Creates a new #GDesktopAppInfo.
+		*
+		* Params:
+		*     filename = the path of a desktop file, in the GLib filename encoding
+		*
+		* Return: a new #GDesktopAppInfo or %NULL on error.
+		*
+		* Throws: ConstructionException GTK+ fails to create the object.
+		*/
+		public static DesktopAppInfo createFromFilename(string filename)
+		{
+			auto p = g_desktop_app_info_new_from_filename(Str.toStringz(filename));
+
+			if(p is null)
+			{
+				throw new ConstructionException("null returned by g_desktop_app_info_new_from_filename");
+			}
+
+			return new DesktopAppInfo(p, true);
+		}
+	code: end
+version: end
+
+struct: FileAttributeInfoList
+array: infos n_infos
+
+struct: InetAddress
+noCode: new_any
+noCode: new_loopback
+code: start
+	/**
+	 * Creates a InetAddress for the "any" address (unassigned/"don't
+	 * care") for family.
+	 *
+	 * Params:
+	 *     family = the address family
+	 *     loopback = If true create an InetAddress for the loopback address.
+	 *
+	 * Throws: ConstructionException GTK+ fails to create the object.
+	 *
+	 * Since: 2.22
+	 */
+	public this (GSocketFamily family, bool loopback = false)
+	{
+		GInetAddress* p;
+
+		if ( loopback )
+		{
+			p = g_inet_address_new_loopback(family);
+		}
+		else
+		{
+			p = g_inet_address_new_any(family);
+		}
+
+		if(p is null)
+		{
+			throw new ConstructionException("null returned by g_inet_address_new_any(family)");
+		}
+		this(p, true);
+	}
+code: end
+
+struct: NoExternal
+noCode: true
+noExternal: true
+
+struct: IOModule
+move: load NoExternal
+move: unload NoExternal
+move: query NoExternal
+
+struct: MenuItem
+noCode: new_section
+noCode: new_submenu
+
+struct: OutputStream
+out: vprintf error
+
+struct: PollableUtils
+namespace:
+
+struct: Resource
+alias: _register register
+alias: _unregister unregister
+
+struct: SimpleAsyncResult
+noCode: new_take_error
+
+struct: SimpleProxyResolver
+array: new ignore_hosts
+array: set_ignore_hosts ignore_hosts
+
+struct: Socket
+ref: receive buffer
+ref: receive_from buffer
+out: receive_message messages
+out: receive_message num_messages
+
+struct: SubprocessLauncher
+array: set_environ env
+
+struct: ThemedIcon
+noCode: new
+
+struct: TlsPassword
+out: get_value length
+array: get_value Return length
+array: set_value value length
+array: set_value_full value length
+
+version !Windows: start
+	struct: UnixMountEntry
+	class: UnixMountEntry
+
+	struct: UnixSocketAddress
+	noCode: new_abstract
+version: end
+
+struct: VolumeMonitor
+import: glib.ConstructionException
+noCode: get
+code: start
+	/**
+	 * Gets the volume monitor used by gio.
+	 *
+	 * Return: a reference to the #GVolumeMonitor used by gio. Call
+	 *     g_object_unref() when done with it.
+	 */
+	public this()
+	{
+		auto p = g_volume_monitor_get();
+
+		if(p is null)
+		{
+			throw new ConstructionException("g_volume_monitor_get()");
+		}
+
+		this(cast(GVolumeMonitor*) p, true);
+	}
+code: end
+
+struct:
+
+move: bus_get DBusConnection get
+move: bus_get_finish DBusConnection get_finish
+move: bus_get_sync DBusConnection get_sync
+
+move: bus_own_name DBusNames own_name
+move: bus_own_name_on_connection DBusNames own_name_on_connection
+move: bus_own_name_on_connection_with_closures DBusNames own_name_on_connection_with_closures
+move: bus_own_name_with_closures DBusNames own_name_with_closures
+move: bus_unown_name DBusNames unown_name
+move: bus_unwatch_name DBusNames unwatch_name
+move: bus_watch_name DBusNames watch_name
+move: bus_watch_name_on_connection DBusNames watch_name_on_connection
+move: bus_watch_name_on_connection_with_closures DBusNames watch_name_on_connection_with_closures
+move: bus_watch_name_with_closures DBusNames watch_name_with_closures
+
+move: content_type_can_be_executable ContentType can_be_executable
+move: content_type_equals ContentType equals
+move: content_type_from_mime_type ContentType from_mime_type
+move: content_type_get_description ContentType get_description
+move: content_type_get_generic_icon_name ContentType get_generic_icon_name
+move: content_type_get_icon ContentType get_icon
+move: content_type_get_mime_type ContentType get_mime_type
+move: content_type_get_symbolic_icon ContentType get_symbolic_icon
+move: content_type_guess ContentType type_guess
+move: content_type_guess_for_tree ContentType guess_for_tree
+move: content_type_is_a ContentType is_a
+move: content_type_is_unknown ContentType is_unknown
+move: content_types_get_registered ContentType
+version 2.52: move: content_type_is_mime_type ContentType is_mime_type
+
+move: dbus_error_encode_gerror DBusError encode_gerror
+move: dbus_error_get_remote_error DBusError get_remote_error
+move: dbus_error_is_remote_error DBusError is_remote_error
+move: dbus_error_new_for_dbus_error DBusError new_for_dbus_error
+move: dbus_error_quark DBusError quark
+move: dbus_error_register_error DBusError register_error
+move: dbus_error_register_error_domain DBusError register_error_domain
+move: dbus_error_strip_remote_error DBusError strip_remote_error
+move: dbus_error_unregister_error DBusError unregister_error
+
+move: dbus_address_escape_value DBusUtilities address_escape_value
+move: dbus_address_get_for_bus_sync DBusUtilities address_get_for_bus_sync
+move: dbus_address_get_stream DBusUtilities address_get_stream
+move: dbus_address_get_stream_finish DBusUtilities address_get_stream_finish
+move: dbus_address_get_stream_sync DBusUtilities address_get_stream_sync
+move: dbus_generate_guid DBusUtilities generate_guid
+move: dbus_gvalue_to_gvariant DBusUtilities gvalue_to_gvariant
+move: dbus_gvariant_to_gvalue DBusUtilities gvariant_to_gvalue
+move: dbus_is_address DBusUtilities is_address
+move: dbus_is_guid DBusUtilities is_guid
+move: dbus_is_interface_name DBusUtilities is_interface_name
+move: dbus_is_member_name DBusUtilities is_member_name
+move: dbus_is_name DBusUtilities is_name
+move: dbus_is_supported_address DBusUtilities is_supported_address
+move: dbus_is_unique_name DBusUtilities is_unique_name
+
+struct: DBusUtilities
+out: address_get_stream_finish out_guid
+out: address_get_stream_sync out_guid
+
+move: io_error_from_errno ErrorGIO
+move: io_error_quark ErrorGIO
+
+move: io_modules_load_all_in_directory IOModule load_all_in_directory
+move: io_modules_load_all_in_directory_with_scope IOModule load_all_in_directory_with_scope
+move: io_modules_scan_all_in_directory IOModule scan_all_in_directory
+move: io_modules_scan_all_in_directory_with_scope IOModule scan_all_in_directory_with_scope
+
+move: io_scheduler_cancel_all_jobs IOSchedulerJob cancel_all_jobs
+move: io_scheduler_push_job IOSchedulerJob push_job
+
+move: pollable_source_new PollableUtils
+move: pollable_source_new_full PollableUtils
+move: pollable_stream_read PollableUtils
+move: pollable_stream_write PollableUtils
+move: pollable_stream_write_all PollableUtils
+
+move: resources_enumerate_children Resource
+move: resources_get_info Resource
+move: resources_lookup_data Resource
+move: resources_open_stream Resource
+move: resources_register Resource _register
+move: resources_unregister Resource _unregister
+
+move: keyfile_settings_backend_new SettingsBackend
+move: memory_settings_backend_new SettingsBackend
+move: null_settings_backend_new SettingsBackend
+
+move: simple_async_report_error_in_idle SimpleAsyncResult
+move: simple_async_report_gerror_in_idle SimpleAsyncResult
+move: simple_async_report_take_gerror_in_idle SimpleAsyncResult
+
+version !Windows: start
+	move: unix_is_mount_path_system_internal UnixMountEntry is_mount_path_system_internal
+	move: unix_mount_at UnixMountEntry at
+	move: unix_mount_compare UnixMountEntry compare
+	move: unix_mount_free UnixMountEntry free
+	move: unix_mount_get_device_path UnixMountEntry get_device_path
+	move: unix_mount_get_fs_type UnixMountEntry get_fs_type
+	move: unix_mount_get_mount_path UnixMountEntry get_mount_path
+	move: unix_mount_guess_can_eject UnixMountEntry guess_can_eject
+	move: unix_mount_guess_icon UnixMountEntry guess_icon
+	move: unix_mount_guess_name UnixMountEntry guess_name
+	move: unix_mount_guess_should_display UnixMountEntry guess_should_display
+	move: unix_mount_guess_symbolic_icon UnixMountEntry guess_symbolic_icon
+	move: unix_mount_is_readonly UnixMountEntry is_readonly
+	move: unix_mount_is_system_internal UnixMountEntry is_system_internal
+	move: unix_mount_points_changed_since UnixMountEntry points_changed_since
+	move: unix_mount_points_get UnixMountEntry mount_points_get
+	move: unix_mounts_changed_since UnixMountEntry mounts_changed_since
+	move: unix_mounts_get UnixMountEntry mounts_get
+
+	version 2.54: start
+		move: unix_mount_copy UnixMountEntry copy
+		move: unix_mount_for UnixMountEntry mount_for
+	version: end
+version: end

--- a/wrap/meson/create-temp-girtod.py
+++ b/wrap/meson/create-temp-girtod.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Creates a temporary girtod binary that we can run in Meson's configure phase
+# in order to get a list of the generated source files in advance.
+
+import os
+import sys
+import subprocess
+
+meson_build_root = os.environ.get('MESON_BUILD_ROOT')
+meson_source_root = os.environ.get('MESON_SOURCE_ROOT')
+
+if not meson_build_root or not meson_source_root:
+    print('This script should only be run by the Meson build system.')
+    sys.exit(1)
+
+
+# This is an epic hack, but it ensures that we build both the library and girtod itself with the right
+# compiler flags.
+# We can not use Meson's normal generator helper, because we do not know the files girtod generates in advance.
+
+temp_build_dir = os.path.join(meson_build_root, 'tmp_girtod')
+os.makedirs(temp_build_dir, exist_ok=True)
+
+os.chdir(temp_build_dir)
+
+meson_cmd = ['meson',
+             '--buildtype=debugoptimized',
+             '-Dbuild-glibd=false',
+             os.path.relpath(meson_source_root, temp_build_dir)]
+
+# configure
+subprocess.run(meson_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+# make
+subprocess.run('ninja', check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/wrap/meson/generate-bindings.py
+++ b/wrap/meson/generate-bindings.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import glob
+import subprocess
+
+meson_build_root = os.environ.get('MESON_BUILD_ROOT')
+meson_source_root = os.environ.get('MESON_SOURCE_ROOT')
+
+if not meson_build_root or not meson_source_root:
+    print('This script should only be run by the Meson build system.')
+    sys.exit(1)
+
+if len(sys.argv) != 2:
+    print('Invalid number of arguments: Need only the path to wrap files.')
+    sys.exit(1)
+
+girtod_binary = os.path.join(meson_build_root, 'tmp_girtod', 'girtod')
+sources_dir = os.path.join(meson_build_root, 'wrap.gen', 'glibd')
+os.makedirs(sources_dir, exist_ok=True)
+
+girtod_cmd = [girtod_binary,
+             '-i', sys.argv[1],
+             '-o', sources_dir]
+
+# generate bindings
+subprocess.run(girtod_cmd, check=True)
+
+files = glob.glob(os.path.join(sources_dir, '**', '*.d'), recursive=True)
+for fname in sorted(files):
+    # newer versions of Meson (>= 0.43) don't like absolute paths
+    print(os.path.relpath(fname, meson_source_root))


### PR DESCRIPTION
Hi!

This enhances the Meson build definition to not only generate the `girtod` binary, but also produce a new `glibd-2.0` binary.
I am using `girtod` in a few projects now, which are all non-GUI and therefore only need GLib (and an additional library wrapped). Always building the entire GLib D bindings source code is incredibly time consuming for projects, and given that pretty much every single project using gir-to-d will need to link against the wrapped glib D code, I think it makes a lot of sense to ship an autogenerated glibd library with the gir-to-d binary itself.

The new code messes with Meson quite a bit. Meson (and make/ninja) have the concept of "generators" to generate new file targets using a custom command. The problem is that we need to know the names of the generated files in advance, which is not (easily) the case with `girtod` which generates a bunch of new directories and D sources.
We could split out the generate/build step into an entirely new custom command, but then we would have to do all the D compiler detection, build-flags setting etc. manually again, which sucks and will break for sure at some point.

The solution I went with here due to that is to build a scratch girtod binary when configuring the Meson project, and use that to produce the sources to then use a regular library target with.
This has a drawback too, first it's quite ugly, and second when running ninja again, we will only ever recompile the girtod source code, but not regenerate the library sources with the new girtod. So, when developing girtod, this must be accounted for.

The wrap files for the new glibd library are taken from current GtkD Git master.

I know this is quite an invasive change, and I initially wanted to file a bug asking @MikeWey to give us some glibd library, but then I thought that providing a patch might be a better way to open this discussion.

Please give this patch a try!
Unfortunately I have absolutely no idea on how to implement this with dub - the only thing I can think of that might work with dub is to have two separate dub.json files, one building girtod, and the other one calling the generated girtod to produce library sources.

I hope you find this patch helpful! It will fix the code-duplication and recompilation issue for projects using Makefiles and Meson, for dub we will likely need a different solution though (unless dub fixes its global package registry support, in which case we could make it so that dub users could use the Meson-installed stuff as well). Easiest for dub would likely be to just ship pregenerated files in Git, which is a bit ugly as well though.
