### PR TITLE
GirFunction: Properly translate signal name starting with '-'

### DIFF
--- a/source/gtd/GirFunction.d
+++ b/source/gtd/GirFunction.d
@@ -1034,7 +1034,7 @@ final class GirFunction
 
 		foreach ( size_t count, char c; name )
 		{
-			if ( count == 0 )
+			if ( count == 0 && c != '-')
 			{
 				signalName ~= toUpper(c);
 			}


### PR DESCRIPTION
Signal names can start with a hypen, for example "-gtk-private". This
would previously translate to wrappers like "onAdd-GtkPrivate" which is
not proper D syntax of course. Translate the signal name to "GtkPrivate"
instead so the wrapper function ends up as "addOnGtkPrivate".