### PR TITLE
Stability improvements for valac generated gir files.

### DIFF
--- a/source/gtd/GirConstant.d
+++ b/source/gtd/GirConstant.d
@@ -60,6 +60,7 @@ final class GirConstant
 			switch(reader.front.value)
 			{
 				case "type":
+				case "array":
 					type = new GirType(wrapper);
 					type.parse(reader);
 					break;

--- a/source/gtd/GirFunction.d
+++ b/source/gtd/GirFunction.d
@@ -344,7 +344,9 @@ final class GirFunction
 		}
 
 		if ( throws )
-			ext ~= ", GError** err";
+		{
+			ext ~= (params.length == 0 ? "GError** err" : ", GError** err");
+		}
 
 		return ext;
 	}
@@ -822,7 +824,7 @@ final class GirFunction
 		if ( throws )
 		{
 			buff ~= "GError* err = null;";
-			gtkCall ~= ", &err";
+			gtkCall ~= (params.length == 0 ? "&err" : ", &err");
 		}
 
 		enum throwGException = [

--- a/source/gtd/GirPackage.d
+++ b/source/gtd/GirPackage.d
@@ -203,6 +203,10 @@ final class GirPackage
 					// We are not able to wrap these.
 					reader.skipTag();
 					break;
+				case "field":
+					// We are not able to wrap these.
+					reader.skipTag();
+					break;
 				default:
 					error("Unexpected tag: ", reader.front.value, " in GirPackage: ", name, reader);
 			}
@@ -221,7 +225,7 @@ final class GirPackage
 			stockIDs.members ~= member;
 			return;
 		}
-		else if ( reader.front.attributes["c:type"].startsWith("GDK_KEY_") )
+		else if ( "c:type" in reader.front.attributes && reader.front.attributes["c:type"].startsWith("GDK_KEY_") )
 		{
 			GirEnumMember member = GirEnumMember(wrapper);
 			member.parse(reader);

--- a/source/gtd/GirType.d
+++ b/source/gtd/GirType.d
@@ -69,6 +69,10 @@ final class GirType
 		if ( cType is null && name is null )
 		{
 			name = "none";
+		}
+
+		// Some GIR files have a none type name.
+		if (name == "none") {
 			cType = "void";
 		}
 


### PR DESCRIPTION
There's still some Vala related things to sort out. (For example when vala code refers to an object by namespace, etc.)

This PR adds the following:
 * Support for functions that return void but that have type="none" already defined in GIR
 * Support for functions with no parameters, but that still throws an exception
 * Support for constants with array values.
 * Support for skipping field tags at package level. (Some valac generated GIR files have fields in package scope)

There's also added a check, as some GIR constants don't define their type with the type attribute, so just verifying it exists before trying to fetch anything from it.