### PR TITLE
Fix memory leak if return type is strv with container transfer mode

### DIFF
--- a/source/gtd/GirFunction.d
+++ b/source/gtd/GirFunction.d
@@ -911,7 +911,8 @@ final class GirFunction
 		}
 		else if ( returnType.isString() )
 		{
-			if ( outToD.empty && !throws && !(returnOwnership == GirTransferOwnership.Full) )
+			if ( outToD.empty && !throws &&
+			     !(returnOwnership == GirTransferOwnership.Full || returnOwnership == GirTransferOwnership.Container) )
 			{
 				if ( isStringArray(returnType) )
 					buff ~= "return Str.toStringArray(" ~ gtkCall ~");";
@@ -942,6 +943,10 @@ final class GirFunction
 					buff ~= "scope(exit) Str.freeStringArray(retStr);";
 				else
 					buff ~= "scope(exit) Str.freeString(retStr);";
+			} else if ( returnOwnership == GirTransferOwnership.Container )
+			{
+				if ( isStringArray(returnType) )
+					buff ~= "scope(exit) g_free(retStr);";
 			}
 
 			string len = lenId(returnType);

--- a/source/gtd/GirStruct.d
+++ b/source/gtd/GirStruct.d
@@ -930,8 +930,10 @@ final class GirStruct
 					else
 						imports ~= dType.pack.name ~"."~ dType.name;
 				}
-				else if ( field.type.isString() || (field.type.isArray() && field.type.elementType.isString())  )
+				else if ( field.type.isString() || (field.type.isArray() && field.type.elementType.isString())  ) {
 					imports ~= "glib.Str";
+					imports ~= "glib.c.functions";
+				}
 			}
 		}
 
@@ -969,8 +971,10 @@ final class GirStruct
 					else
 						imports ~= dType.pack.name ~"."~ dType.name;
 				}
-				else if ( type.name.among("utf8", "filename") || type.cType.among("guchar**") )
+				else if ( type.name.among("utf8", "filename") || type.cType.among("guchar**") ) {
 					imports ~= "glib.Str";
+					imports ~= "glib.c.functions";
+				}
 			}
 
 			if ( func.returnType && func.returnType.cType !in structWrap )


### PR DESCRIPTION
Hi!
Functions may return a `const gchar**` with `(transfer container)`, in which case the caller has to free the surrounding "container" with `g_free` to not create a memory leak.
This patch makes gir-to-d follow that behavior.
I include the `glib.c.functions` module now for `g_free` - using `Str.freeString` would also have worked, as that just calls `g_free`, but that would have required a typecast, and we are freeing a memory segment here and not a string, so I found just using `g_free` to be more appropriate.
Cheers,
   Matthias
