### PR TITLE
Improve gir file lookup

### DIFF
--- a/source/gtd/GirWrapper.d
+++ b/source/gtd/GirWrapper.d
@@ -595,10 +595,6 @@ class GirWrapper
 		{
 			return dirs;
 		}
-		else
-		{
-			dirs = [];
-		}
 
 		if ( commandlineGirPath )
 		{

--- a/source/gtd/GirWrapper.d
+++ b/source/gtd/GirWrapper.d
@@ -622,11 +622,12 @@ class GirWrapper
 			{
 				dirs ~= path.buildNormalizedPath("../share/gir-1.0");
 			}
+
 			path = environment.get("HOMEBREW_ROOT");
 			if(path)
-				{
-					dirs ~= path.buildNormalizedPath("share/gir-1.0");
-				}
+			{
+				dirs ~= path.buildNormalizedPath("share/gir-1.0");
+			}
 		}
 		else
 		{

--- a/source/gtd/GirWrapper.d
+++ b/source/gtd/GirWrapper.d
@@ -605,8 +605,6 @@ class GirWrapper
 		{
 			foreach (p; splitter(environment.get("PATH"), ';'))
 			{
-				string dllPath = buildNormalizedPath(p, "libgtk-3-0.dll");
-
 				dirs ~= p.buildNormalizedPath("../share/gir-1.0");
 			}
 
@@ -634,7 +632,7 @@ class GirWrapper
 		        }
 		}
 
-		return dirs;
+		return dirs.filter!(p=> exists(p) && isDir(p) ).array;
 	}
 
 	private GirParam findParam(GirStruct strct, string func, string name)


### PR DESCRIPTION
This makes the getGirDirectory function return multiple possible
candidate directories and makes it behave according to the XDG_DATA_DIRS
spec on linux.

Resolves https://github.com/gtkd-developers/gir-to-d/issues/36

Please note that:
1. I haven't tested this commit on systems other than linux
2. I'm just learning D/gtk